### PR TITLE
Working zstd support!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,23 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 
 js-sys = "0.3.53"
 getrandom = { version = "0.2.3", features = ["js"] }
-arrow = { version = "9.1.0", default-features = false }
-parquet = { version = "9.1.0", default-features = false, features = [
+arrow = { git = "https://github.com/kylebarron/arrow-rs", branch = "zstd-upstream", default-features = false }
+
+# arrow = { version = "9.1.0", default-features = false }
+parquet = { git = "https://github.com/kylebarron/arrow-rs", branch = "zstd-upstream", default-features = false, features = [
   "snap",
   "arrow",
   "base64",
   "flate2",
+  "zstd",
 ] }
+# parquet = { version = "9.1.0", default-features = false, features = [
+#   "snap",
+#   "arrow",
+#   "base64",
+#   "flate2",
+#   "zstd",
+# ] }
 web-sys = { version = "0.3", features = ["console"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub fn read_parquet(parquet_file_bytes: &[u8]) -> Result<Uint8Array, JsValue> {
         Compression::SNAPPY,
         Compression::UNCOMPRESSED,
         Compression::GZIP,
+        Compression::ZSTD,
     ];
 
     let parquet_bytes_as_vec = parquet_file_bytes.to_vec();


### PR DESCRIPTION
Needs [this unreleased commit](https://github.com/gyscos/zstd-rs/commit/d6bfa32d09b8e4ef747c9b57109974c270ffab72) from `zstd-rs`, which was merged on Jan 28, and didn't make it into version [`0.10.0`](https://github.com/gyscos/zstd-rs/releases/tag/v0.10.0). 

It also needs `default-features = false` on `zstd`. That will be a change necessary in `arrow-rs`. It looks like the only string of `zstd::` in `arrow-rs` is in `parquet/src/compression.rs`, and that seems to work fine with `default-features=false`. So this update in Arrow shouldn't be an issue.

Also needs to use the non-Apple `clang` for compiling. Ref https://github.com/rust-bitcoin/rust-secp256k1/issues/283#issuecomment-891387607 and https://github.com/rust-bitcoin/rust-secp256k1/issues/283#issuecomment-960068019 and the upstream `zstd` issue https://github.com/gyscos/zstd-rs/issues/93. When only `PATH` was updated but not `CC` or `AR`, I got `error: failed to build archive: section too large`.

Repro:
```
brew install llvm
export PATH="/usr/local/opt/llvm/bin/:$PATH"
export CC=/usr/local/opt/llvm/bin/clang
export AR=/usr/local/opt/llvm/bin/llvm-ar
```