### PR TITLE
ESM Example

### DIFF
--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -1,0 +1,77 @@
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <!-- Script tag for Apache Arrow -->
+    <script src="https://cdn.jsdelivr.net/npm/@apache-arrow/es2015-umd/Arrow.js"></script>
+    <!-- Note the usage of `type=module` here as this is an ES6 module -->
+    <script type="module">
+      // Use ES module import syntax to import functionality from the module
+      // that we have compiled.
+      //
+      // Note that the `default` import is an initialization function which
+      // will "boot" the module and make it ready to use. Currently browsers
+      // don't support natively imported WebAssembly as an ES module, but
+      // eventually the manual initialization won't be required!
+      import init, {
+        readParquet,
+      } from "https://cdn.jsdelivr.net/npm/parquet-wasm@0.1.1/web.js";
+
+      async function run() {
+        // First up we need to actually load the wasm file, so we use the
+        // default export to inform it where the wasm file is located on the
+        // server, and then we wait on the returned promise to wait for the
+        // wasm to be loaded.
+        //
+        // It may look like this: `await init('./pkg/without_a_bundler_bg.wasm');`,
+        // but there is also a handy default inside `init` function, which uses
+        // `import.meta` to locate the wasm file relatively to js file.
+        //
+        // Note that instead of a string you can also pass in any of the
+        // following things:
+        //
+        // * `WebAssembly.Module`
+        //
+        // * `ArrayBuffer`
+        //
+        // * `Response`
+        //
+        // * `Promise` which returns any of the above, e.g. `fetch("./path/to/wasm")`
+        //
+        // This gives you complete control over how the module is loaded
+        // and compiled.
+        //
+        // Also note that the promise, when resolved, yields the wasm module's
+        // exports which is the same as importing the `*_bg` module in other
+        // modes
+        await init();
+        // And afterwards we can use all the functionality defined in wasm.
+
+        // Note this is a 257MiB file!
+        // TODO: find a smaller Parquet file somewhere :)
+        const parquetUrl =
+          "https://ookla-open-data.s3.us-west-2.amazonaws.com/parquet/performance/type=mobile/year=2019/quarter=1/2019-01-01_performance_mobile_tiles.parquet";
+
+        const resp = await fetch(parquetUrl);
+        const arrayBuffer = await resp.arrayBuffer();
+        const arr = new Uint8Array(arrayBuffer);
+        console.log("loaded data!");
+
+        console.time("parse Parquet");
+        const arrowIPC = readParquet(arr);
+        console.timeEnd("parse Parquet");
+
+        const table = Arrow.tableFromIPC(arrowIPC);
+        console.log("loaded arrow table!");
+
+        window.arrayBuffer = arrayBuffer;
+        window.arr = arr;
+        window.table = table;
+        window.readParquet = readParquet;
+      }
+
+      run();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Should find a smaller Parquet file or better notify that this will download a 270MB file 😄 

This expands in memory to a 755MB Arrow file. It takes 6s in WASM vs 1.25s in Pyarrow with threads turned off. That extra time might be in copying the buffer to/from WASM memory?

Closes #12