### PR TITLE
Writer options

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,0 +1,57 @@
+use wasm_bindgen::prelude::*;
+
+// I can't just re-export the ParquetCompression enum because enums with #[wasm_bindgen] may only
+// have number literal values
+#[wasm_bindgen]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub enum Compression {
+    UNCOMPRESSED,
+    SNAPPY,
+    GZIP,
+    BROTLI,
+    LZ4,
+    ZSTD,
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub enum Encoding {
+    /// Default encoding.
+    /// BOOLEAN - 1 bit per value. 0 is false; 1 is true.
+    /// INT32 - 4 bytes per value.  Stored as little-endian.
+    /// INT64 - 8 bytes per value.  Stored as little-endian.
+    /// FLOAT - 4 bytes per value.  IEEE. Stored as little-endian.
+    /// DOUBLE - 8 bytes per value.  IEEE. Stored as little-endian.
+    /// BYTE_ARRAY - 4 byte length stored as little endian, followed by bytes.
+    /// FIXED_LEN_BYTE_ARRAY - Just the bytes.
+    PLAIN,
+    /// Deprecated: Dictionary encoding. The values in the dictionary are encoded in the
+    /// plain type.
+    /// in a data page use RLE_DICTIONARY instead.
+    /// in a Dictionary page use PLAIN instead
+    PLAIN_DICTIONARY,
+    /// Group packed run length encoding. Usable for definition/repetition levels
+    /// encoding and Booleans (on one bit: 0 is false; 1 is true.)
+    RLE,
+    /// Bit packed encoding.  This can only be used if the data has a known max
+    /// width.  Usable for definition/repetition levels encoding.
+    BIT_PACKED,
+    /// Delta encoding for integers. This can be used for int columns and works best
+    /// on sorted data
+    DELTA_BINARY_PACKED,
+    /// Encoding for byte arrays to separate the length values and the data. The lengths
+    /// are encoded using DELTA_BINARY_PACKED
+    DELTA_LENGTH_BYTE_ARRAY,
+    /// Incremental-encoded byte array. Prefix lengths are encoded using DELTA_BINARY_PACKED.
+    /// Suffixes are stored as delta length byte arrays.
+    DELTA_BYTE_ARRAY,
+    /// Dictionary encoding: the ids are encoded using the RLE encoding
+    RLE_DICTIONARY,
+    /// Encoding for floating-point data.
+    /// K byte-streams are created where K is the size in bytes of the data type.
+    /// The individual bytes of an FP value are scattered to the corresponding stream and
+    /// the streams are concatenated.
+    /// This itself does not reduce the size of the data but can lead to better compression
+    /// afterwards.
+    BYTE_STREAM_SPLIT,
+}

--- a/src/write_options.rs
+++ b/src/write_options.rs
@@ -1,0 +1,20 @@
+use crate::enums::{Compression, Encoding};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Copy, Clone, Debug)]
+pub struct WriteOptions {
+    pub compression: Compression,
+    pub encoding: Encoding,
+}
+
+#[wasm_bindgen]
+impl WriteOptions {
+    #[wasm_bindgen(constructor)]
+    pub fn new(compression: Compression, encoding: Encoding) -> Self {
+        Self {
+            compression: compression,
+            encoding: encoding
+        }
+    }
+}

--- a/src/write_options.rs
+++ b/src/write_options.rs
@@ -1,3 +1,5 @@
+use js_sys::{Object, Reflect};
+use arrow2::io::parquet::write::{WriteOptions as UpstreamWriteOptions};
 use crate::enums::{Compression, Encoding};
 use wasm_bindgen::prelude::*;
 
@@ -8,13 +10,52 @@ pub struct WriteOptions {
     pub encoding: Encoding,
 }
 
+
 #[wasm_bindgen]
-impl WriteOptions {
-    #[wasm_bindgen(constructor)]
-    pub fn new(compression: Compression, encoding: Encoding) -> Self {
-        Self {
-            compression: compression,
-            encoding: encoding
-        }
+pub struct WriteOptions(arrow2::io::parquet::write::WriteOptions);
+
+#[wasm_bindgen]
+pub fn temp(options: &JsValue) -> Result<(), JsValue> {
+    if (options.is_undefined()) {
+        return Ok(());
     }
+
+    let message: JsValue = Reflect::get(&options, &JsValue::from_str("message"))?;
+    log!("{:?}", message.as_string().unwrap());
+    Ok(())
 }
+
+// #[wasm_bindgen]
+// impl WriteOptions {
+//     #[wasm_bindgen(constructor)]
+//     pub fn new(options: &JsValue) -> Self {
+//         let message: JsValue = Reflect::get(&options, &JsValue::from_str("message"))?;
+
+
+//         options.ok
+//         Self {
+//             write_statistics:
+//             compression: compression,
+//             encoding: encoding
+//         }
+//     }
+// }
+
+// # [wasm_bindgen]
+// pub fn greet(ele: &JsValue, options: &JsValue) -> Result<(), JsValue> {
+//   match ele.dyn_ref::<HtmlDivElement>() {
+//     Some(div) => {
+//       if (options.is_undefined()) {
+//         div.set_inner_text("Hello from Rust");
+//       } else {
+//         let message: JsValue = Reflect::get(&options, &JsValue::from_str("message"))?;
+//         let message = message.as_string().unwrap();
+//         div.set_inner_text(&message);
+//       }
+//       Ok(())
+//     }
+//     None => Err(JsValue::from_str("ele must be a div"))
+//   }
+// }
+
+


### PR DESCRIPTION
## Change list

- Add support for setting compression and encoding when writing parquet files
- Exposes `Compression` and `Encoding` enums to JS as well as the `WriteOptions` struct

## Todo

- [ ] Use upstream struct definitions? I.e. use 
	  
  ```rs
  #[wasm_bindgen]
  pub struct WriteOptions(arrow2::io::parquet::write::WriteOptions);
  ``` 
- [ ] Use JS Object for the constructor for write options? Something like [this](https://users.rust-lang.org/t/wasm-bindgen-how-do-you-create-a-function-with-an-optional-parameter-object/40067/3)?

- [ ] ~~Per-column compression~~ looks like compression is per file; just encoding is per-column. Maybe have both `defaultEncoding` and `encodingMap` in `writeOptions`? So if a column name is found in `encodingMap` it'll use that, but otherwise fall back to `defaultEncoding`?
- [ ] Per-column encoding
- [ ] Which encodings are supported in Parquet2 for writing?
- [ ] Nicer API for creating WriteOptions? Positional-only args for compression and encoding? Any way to have default values?