### PR TITLE
Faster builds on Node CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: "16"
 
       - name: Build bundle
-        run: bash ./scripts/build.sh
+        run: bash ./scripts/build-node-tests.sh
 
       - name: Install dev dependencies
         run: yarn

--- a/scripts/build-node-tests.sh
+++ b/scripts/build-node-tests.sh
@@ -9,7 +9,7 @@ rm -rf pkg pkg_node pkg_web
 # Build node version into pkg_node
 echo "Building arrow-rs node"
 wasm-pack build \
-  --release \
+  --dev \
   --out-dir pkg \
   --out-name node \
   --target nodejs
@@ -19,7 +19,7 @@ wasm-pack build \
 # Build node version into pkg2_node
 echo "Building arrow2 node"
 wasm-pack build \
-  --release \
+  --dev \
   --out-dir pkg2_node \
   --out-name node2 \
   --target nodejs \

--- a/scripts/build-node-tests.sh
+++ b/scripts/build-node-tests.sh
@@ -1,0 +1,35 @@
+#! /usr/bin/env bash
+
+# Build script used in Node-only CI tests
+
+rm -rf pkg pkg_node pkg_web
+
+######################################
+# ARROW 1 (arrow-rs) the default feature
+# Build node version into pkg_node
+echo "Building arrow-rs node"
+wasm-pack build \
+  --release \
+  --out-dir pkg \
+  --out-name node \
+  --target nodejs
+
+######################################
+# ARROW 2 turn on the feature manually
+# Build node version into pkg2_node
+echo "Building arrow2 node"
+wasm-pack build \
+  --release \
+  --out-dir pkg2_node \
+  --out-name node2 \
+  --target nodejs \
+  --no-default-features \
+  --features arrow2
+
+# Copy files into pkg/
+cp pkg2_node/{node2.d.ts,node2.js,node2_bg.wasm,node2_bg.wasm.d.ts} pkg/
+
+# Update files array using JQ
+jq '.files += ["node2.d.ts", "node2.js", "node2_bg.wasm", "node2_bg.wasm.d.ts"]' pkg/package.json > pkg/package.json.tmp
+# Overwrite existing file
+mv pkg/package.json.tmp pkg/package.json

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-rm -rf pkg pkg_node pkg_web
+rm -rf pkg pkg_node pkg_web pkg2_node pkg2_web pkg2
 
 ######################################
 # ARROW 1 (arrow-rs) the default feature


### PR DESCRIPTION
Only build Node bundles during Node CI runs. Closes #35 