### PR TITLE
Keep opt-level = s and remove `console_error_panic_hook`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["console_error_panic_hook", "arrow1"]
+default = ["arrow1"]
 arrow1 = ["arrow", "parquet"]
 
 [dependencies]
@@ -54,5 +54,7 @@ wasm-bindgen-test = "0.3.13"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.
-opt-level = "z"
+# As of 3/15/22, opt-level = s was smallest
+# https://github.com/kylebarron/parquet-wasm/pull/48
+opt-level = "s"
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,5 @@ wasm-bindgen-test = "0.3.13"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.
-opt-level = "s"
+opt-level = "z"
 lto = true


### PR DESCRIPTION
Saves 331KB on the uncompressed default wasm bundle.

Although this actually makes the brotli-compressed wasm bundle 1kb _larger_!! Though the gzip-compressed wasm bundle is still 60kb smaller.

Brotli encoded wasm sizes (with arrow1):

- `opt-level = s` with console_error_panic_hook: 855246
- `opt-level = s` without console_error_panic_hook: 824049
- `opt-level = z` with console_error_panic_hook: 856203
- `opt-level = z` without console_error_panic_hook: 855934

So let's go with `opt-level = s` and without `console_error_panic_hook` as the default

Closes https://github.com/kylebarron/parquet-wasm/issues/45