### PR TITLE
Update bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,6 @@ node_modules
 /target
 **/*.rs.bk
 pkg/
-pkg_node/
-pkg_web/
-pkg2/
-pkg2_node/
-pkg2_web/
 wasm-pack.log
 .idea/
 www/data

--- a/README.md
+++ b/README.md
@@ -34,26 +34,26 @@ Presumably no one wants to use both `parquet` and `parquet2` at once, so the def
 | Entry point             | Rust crates used        | Description                                             |
 | ----------------------- | ----------------------- | ------------------------------------------------------- |
 | `parquet-wasm`          | `parquet` and `arrow`   | "Bundler" build, to be used in bundlers such as Webpack |
-| `parquet-wasm/node`     | `parquet` and `arrow`   | Node build, to be used with `require` in NodeJS         |
-| `parquet-wasm/web`      | `parquet` and `arrow`   | ESM, to be used directly from the Web as an ES Module   |
+| `parquet-wasm/node/arrow1`     | `parquet` and `arrow`   | Node build, to be used with `require` in NodeJS         |
+| `parquet-wasm/esm/arrow1`      | `parquet` and `arrow`   | ESM, to be used directly from the Web as an ES Module   |
 |                         |                         |                                                         |
-| `parquet-wasm/bundler2` | `parquet2` and `arrow2` | "Bundler" build, to be used in bundlers such as Webpack |
-| `parquet-wasm/node2`    | `parquet2` and `arrow2` | Node build, to be used with `require` in NodeJS         |
-| `parquet-wasm/web2`     | `parquet2` and `arrow2` | ESM, to be used directly from the Web as an ES Module   |
+| `parquet-wasm/bundler/arrow2` | `parquet2` and `arrow2` | "Bundler" build, to be used in bundlers such as Webpack |
+| `parquet-wasm/node/arrow2`    | `parquet2` and `arrow2` | Node build, to be used with `require` in NodeJS         |
+| `parquet-wasm/esm/arrow2`     | `parquet2` and `arrow2` | ESM, to be used directly from the Web as an ES Module   |
 
-Note that when using the `/web` and `/web2` bundles, the default export must be awaited. See [here](https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html) for an example.
+Note that when using the `esm` bundles, the default export must be awaited. See [here](https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html) for an example.
 
 ### `parquet` API
 
 This implementation uses the [`arrow`](https://crates.io/crates/arrow) and [`parquet`](https://crates.io/crates/parquet) Rust crates.
 
-Refer to the [API documentation](https://kylebarron.dev/parquet-wasm/modules/bundler.html) for more details and examples.
+Refer to the [API documentation](https://kylebarron.dev/parquet-wasm/modules/bundler_arrow1.html) for more details and examples.
 
 ### `parquet2` API
 
 This implementation uses the [`arrow2`](https://crates.io/crates/arrow2) and [`parquet2`](https://crates.io/crates/parquet2) Rust crates.
 
-Refer to the [API documentation](https://kylebarron.dev/parquet-wasm/modules/bundler2.html) for more details and examples.
+Refer to the [API documentation](https://kylebarron.dev/parquet-wasm/modules/bundler_arrow2.html) for more details and examples.
 
 ### Debug functions
 
@@ -106,7 +106,7 @@ The Parquet specification permits several compression codecs. This library curre
 - [x] Snappy
 - [x] Gzip
 - [x] Brotli
-- [ ] ZSTD. Will be supported using the next versions of the upstream packages `parquet` and `parquet2`.
+- [x] ZSTD. Supported in `arrow1`, will be supported in `arrow2` when the next version of the upstream `parquet2` package is released.
 - [ ] LZ4. Work is progressing but no support yet.
 
 ## Custom builds

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "build:test": "bash ./scripts/build-node-tests.sh",
     "docs:build": "typedoc",
     "docs:publish": "gh-pages -d docs_build",
+    "docs:serve": "cd docs_build && python -m http.server 8081",
     "docs:watch": "typedoc --watch",
     "test": "ts-node node_modules/tape/bin/tape ./tests/js/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "build": "bash ./scripts/build.sh",
+    "build:test": "bash ./scripts/build-node-tests.sh",
     "docs:build": "typedoc",
     "docs:publish": "gh-pages -d docs_build",
     "docs:watch": "typedoc --watch",

--- a/tests/js/arrow1.ts
+++ b/tests/js/arrow1.ts
@@ -1,7 +1,7 @@
 import * as test from "tape";
-import * as wasm from "../../pkg/node";
+import * as wasm from "../../pkg/node/arrow1";
 import { readFileSync } from "fs";
-import { tableFromIPC, tableToIPC, Table } from "apache-arrow";
+import { tableFromIPC, tableToIPC } from "apache-arrow";
 import { testArrowTablesEqual, readExpectedArrowData } from "./utils";
 
 // Path from repo root

--- a/tests/js/arrow2.ts
+++ b/tests/js/arrow2.ts
@@ -1,7 +1,7 @@
 import * as test from "tape";
-import * as wasm from "../../pkg/node2";
+import * as wasm from "../../pkg/node/arrow2";
 import { readFileSync } from "fs";
-import { tableFromIPC, tableToIPC, Table } from "apache-arrow";
+import { tableFromIPC, tableToIPC } from "apache-arrow";
 import { testArrowTablesEqual, readExpectedArrowData } from "./utils";
 
 // Path from repo root

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,3 +1,3 @@
 {
-  "include": ["pkg/*.d.ts"]
+  "include": ["pkg/**/*.d.ts"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,12 +3,12 @@
   "cleanOutputDir": true,
   "darkHighlightTheme": "github-dark",
   "entryPoints": [
-    "pkg/node.d.ts",
-    "pkg/node2.d.ts",
-    "pkg/bundler.d.ts",
-    "pkg/bundler2.d.ts",
-    "pkg/web.d.ts",
-    "pkg/web2.d.ts"
+    "pkg/node/arrow1.d.ts",
+    "pkg/node/arrow2.d.ts",
+    "pkg/bundler/arrow1.d.ts",
+    "pkg/bundler/arrow2.d.ts",
+    "pkg/esm/arrow1.d.ts",
+    "pkg/esm/arrow2.d.ts"
   ],
   "lightHighlightTheme": "github-light",
   "tsconfig": "tsconfig.docs.json",


### PR DESCRIPTION
### Change list

- Structure output bundle in folders:
  - `pkg/node`
  - `pkg/esm`
  - `pkg/bundler`
- Rename `web` to `esm`, since it can be used from Node as well (at least from Node 16) with `import('./pkg/esm/arrow1.js')`
- Add minimal `package.json` with just `{"type": "module"}` to `pkg/esm` directory so that it also works in node out of the box

Closes https://github.com/kylebarron/parquet-wasm/issues/11