### PR TITLE
Test with upstream lz4 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,8 +73,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e387b20dd573a96f36b173d9027483898f944d696521afd74e2caa3c813d86e"
+source = "git+https://github.com/kylebarron/arrow2?rev=41858ed0924cca67873851a647b9b28602039784#41858ed0924cca67873851a647b9b28602039784"
 dependencies = [
  "arrow-format",
  "base64",
@@ -320,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -593,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "log"
@@ -607,6 +606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c51df9d8d4842336c835df1d85ed447c4813baa237d033d95128bf5552ad8a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,12 +622,11 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -778,15 +785,13 @@ dependencies = [
 
 [[package]]
 name = "parquet-format-async-temp"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03abc2f9c83fe9ceec83f47c76cc071bfd56caba33794340330f35623ab1f544"
+checksum = "488c8b5f43521d019fade4bcc0ce88cce5da5fd26eb1d38b933807041f5930bf"
 dependencies = [
  "async-trait",
- "byteorder",
  "futures",
  "integer-encoding 3.0.3",
- "ordered-float",
 ]
 
 [[package]]
@@ -809,17 +814,18 @@ dependencies = [
 [[package]]
 name = "parquet2"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b085f9e78e4842865151b693f6d94bdf7b280af66daa6e3587adeb3106a07e9"
+source = "git+https://github.com/jorgecarleitao/parquet2?rev=20c4d96eff5c472cc91784e43111ac92f7187059#20c4d96eff5c472cc91784e43111ac92f7187059"
 dependencies = [
  "async-stream",
  "bitpacking",
  "brotli",
  "flate2",
  "futures",
+ "lz4_flex",
  "parquet-format-async-temp",
  "snap",
  "streaming-decompression",
+ "zstd",
 ]
 
 [[package]]
@@ -884,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -1099,6 +1105,16 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.10.1"
-source = "git+https://github.com/kylebarron/arrow2?rev=41858ed0924cca67873851a647b9b28602039784#41858ed0924cca67873851a647b9b28602039784"
+source = "git+https://github.com/kylebarron/arrow2?branch=kyle/test-parquet2#56cc516446fe7ce43bf8fab3d70ecf1806d6d098"
 dependencies = [
  "arrow-format",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ js-sys = "0.3.53"
 getrandom = { version = "0.2.6", features = ["js"] }
 web-sys = { version = "0.3", features = ["console"] }
 
-arrow2 = { git = "https://github.com/kylebarron/arrow2", rev = "41858ed0924cca67873851a647b9b28602039784", optional = true, features = [
+arrow2 = { git = "https://github.com/kylebarron/arrow2", branch = "kyle/test-parquet2", optional = true, features = [
   "io_ipc",
   "io_parquet",
   "io_parquet_compression"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ parquet2_supported_compressions = [
   "parquet2/brotli",
   "parquet2/gzip",
   "parquet2/snappy",
+  "parquet2/lz4_flex",
 ]
 
 # Full list of available features
@@ -48,8 +49,7 @@ full = [
   "parquet/zstd",
   "parquet2/brotli",
   "parquet2/gzip",
-  # lz4_flex not implemented yet, pending https://github.com/jorgecarleitao/parquet2/pull/91
-  # "parquet2/lz4",
+  "parquet2/lz4_flex",
   "parquet2/snappy",
   # ZSTD should work in parquet2's next release, already merged
   # "parquet2/zstd",
@@ -76,13 +76,14 @@ js-sys = "0.3.53"
 getrandom = { version = "0.2.6", features = ["js"] }
 web-sys = { version = "0.3", features = ["console"] }
 
-arrow2 = { version = "0.10", optional = true, features = [
+arrow2 = { git = "https://github.com/kylebarron/arrow2", rev = "41858ed0924cca67873851a647b9b28602039784", optional = true, features = [
   "io_ipc",
   "io_parquet",
+  "io_parquet_compression"
 ] }
 # parquet2 is only used indirectly through arrow2, but we define it here so that we can turn on
 # parquet2 features as needed, e.g. with --features parquet2/gzip
-parquet2 = { version = "0.10", default_features = false, optional = true, features = [
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", rev = "20c4d96eff5c472cc91784e43111ac92f7187059", default_features = false, optional = true, features = [
   "stream",
 ] }
 

--- a/src/arrow2/writer.rs
+++ b/src/arrow2/writer.rs
@@ -43,9 +43,8 @@ pub fn write_parquet(
 
         if let Ok(group) = row_groups {
             for maybe_column in group {
-                let column = maybe_column?;
-                let (group, len) = column;
-                parquet_writer.write(group, len)?;
+                let group = maybe_column?;
+                parquet_writer.write(group)?;
             }
         }
     }


### PR DESCRIPTION
```
> cargo run --bin read_parquet2 --features "debug arrow2 reader writer parquet2_supported_compressions" -- --input-file tests/data/1-partition-lz4.parquet --output-file test_lz4.arrow
    Finished dev [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/read_parquet2 --input-file tests/data/1-partition-lz4.parquet --output-file test_lz4.arrow`
Could not read parquet file: External format error: Compression Lz4 is not yet supported
```