### PR TITLE
esm2 entrypoint with no import.meta.url

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -87,6 +87,12 @@ cp tmp_build/bundler/{package.json,LICENSE_APACHE,LICENSE_MIT,README.md} pkg/
 # Create minimal package.json in esm/ folder with type: module
 echo '{"type": "module"}' > pkg/esm/package.json
 
+cp -r pkg/esm pkg/esm2
+sed '/import.meta.url/ s|input|// input|' pkg/esm2/arrow1.js > pkg/esm2/arrow1_new.js
+sed '/import.meta.url/ s|input|// input|' pkg/esm2/arrow2.js > pkg/esm2/arrow2_new.js
+mv pkg/esm2/arrow1_new.js pkg/esm2/arrow1.js
+mv pkg/esm2/arrow2_new.js pkg/esm2/arrow2.js
+
 # Update files array in package.json using JQ
 # Set module field to bundler/arrow1.js
 # Set types field to bundler/arrow1.d.ts


### PR DESCRIPTION
To solve bundling problems in https://github.com/visgl/loaders.gl/pull/2103. I found that the best way to solve the bundling issue for use in another _library_ was to use the node import for node and the esm import for bundling. However the esm bundle created by `wasm-pack` includes `import.meta.url`, which is a syntax error.

I'll leave this functionality undocumented for now because this API could change.

Somewhat related to https://github.com/kylebarron/parquet-wasm/issues/89.

References:
- https://github.com/iotaledger/identity.rs/pull/340