### PR TITLE
Updated row group async reading

### DIFF
--- a/src/arrow2/error.rs
+++ b/src/arrow2/error.rs
@@ -10,6 +10,9 @@ pub enum ParquetWasmError {
 
     #[error(transparent)]
     ParquetError(Box<ParquetError>),
+
+    #[error("Internal error: `{0}`")]
+    InternalError(String),
 }
 
 pub type Result<T> = std::result::Result<T, ParquetWasmError>;

--- a/src/arrow2/metadata.rs
+++ b/src/arrow2/metadata.rs
@@ -1,3 +1,5 @@
+use crate::arrow2::error::WasmResult;
+use arrow2::io::parquet::read::infer_schema;
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 
@@ -76,6 +78,12 @@ impl FileMetaData {
     //     let col_order = self.0.column_order(i);
     //     col_order.
     // }
+
+    #[wasm_bindgen(js_name = arrowSchema)]
+    pub fn arrow_schema(&self) -> WasmResult<crate::arrow2::schema::ArrowSchema> {
+        let schema = infer_schema(&self.0)?;
+        Ok(schema.into())
+    }
 }
 
 impl From<arrow2::io::parquet::read::FileMetaData> for FileMetaData {
@@ -131,6 +139,12 @@ impl RowGroupMetaData {
 impl From<arrow2::io::parquet::read::RowGroupMetaData> for RowGroupMetaData {
     fn from(meta: arrow2::io::parquet::read::RowGroupMetaData) -> Self {
         RowGroupMetaData(meta)
+    }
+}
+
+impl From<RowGroupMetaData> for arrow2::io::parquet::read::RowGroupMetaData {
+    fn from(meta: RowGroupMetaData) -> arrow2::io::parquet::read::RowGroupMetaData {
+        meta.0
     }
 }
 

--- a/src/arrow2/mod.rs
+++ b/src/arrow2/mod.rs
@@ -7,6 +7,9 @@ pub mod reader_async;
 #[cfg(feature = "reader")]
 pub mod metadata;
 
+#[cfg(feature = "reader")]
+pub mod schema;
+
 pub mod wasm;
 
 #[cfg(feature = "writer")]

--- a/src/arrow2/schema.rs
+++ b/src/arrow2/schema.rs
@@ -1,0 +1,27 @@
+use wasm_bindgen::prelude::*;
+
+/// Metadata for a Parquet file.
+#[derive(Debug, Clone)]
+#[wasm_bindgen]
+pub struct ArrowSchema(arrow2::datatypes::Schema);
+
+#[wasm_bindgen]
+impl ArrowSchema {
+    /// Clone this struct in wasm memory.
+    #[wasm_bindgen]
+    pub fn copy(&self) -> Self {
+        ArrowSchema(self.0.clone())
+    }
+}
+
+impl From<arrow2::datatypes::Schema> for ArrowSchema {
+    fn from(schema: arrow2::datatypes::Schema) -> Self {
+        ArrowSchema(schema)
+    }
+}
+
+impl From<ArrowSchema> for arrow2::datatypes::Schema {
+    fn from(meta: ArrowSchema) -> arrow2::datatypes::Schema {
+        meta.0
+    }
+}

--- a/src/arrow2/wasm.rs
+++ b/src/arrow2/wasm.rs
@@ -168,13 +168,16 @@ pub async fn read_metadata_async(
 #[cfg(all(feature = "reader", feature = "async"))]
 pub async fn read_row_group_async(
     url: String,
-    content_length: usize,
-    meta: crate::arrow2::metadata::FileMetaData,
-    i: usize,
+    // content_length: usize,
+    row_group_meta: crate::arrow2::metadata::RowGroupMetaData,
+    arrow_schema: crate::arrow2::schema::ArrowSchema,
 ) -> WasmResult<Uint8Array> {
-    let buffer =
-        crate::arrow2::reader_async::read_row_group(url, content_length, &meta.clone().into(), i)
-            .await?;
+    let buffer = crate::arrow2::reader_async::read_row_group(
+        url,
+        &row_group_meta.into(),
+        &arrow_schema.into(),
+    )
+    .await?;
     copy_vec_to_uint8_array(buffer)
 }
 

--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -1,30 +1,37 @@
+use futures::channel::oneshot;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Request, RequestInit, RequestMode, Response};
 
-use crate::log;
+use wasm_bindgen_futures::spawn_local;
 
 /// Get content-length of file
-pub async fn get_content_length(url: String) -> Result<usize, JsValue> {
-    log!("Constructing requestInit options");
+pub async fn _get_content_length(url: String) -> Result<usize, JsValue> {
     let mut opts = RequestInit::new();
     opts.method("HEAD");
     opts.mode(RequestMode::Cors);
 
-    log!("Constructing request");
     let request = Request::new_with_str_and_init(&url, &opts)?;
     let window = web_sys::window().unwrap();
 
-    log!("Making fetch");
     let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
     let resp: Response = resp_value.dyn_into().unwrap();
 
-    log!("Getting content-length header");
     let length = resp.headers().get("content-length")?;
     let a = length.unwrap();
     let length_int = a.parse::<usize>().unwrap();
     Ok(length_int)
+}
+
+pub async fn get_content_length(url: String) -> Result<usize, JsValue> {
+    let (sender, receiver) = oneshot::channel::<usize>();
+    spawn_local(async move {
+        let inner_data = _get_content_length(url).await.unwrap();
+        sender.send(inner_data).unwrap();
+    });
+    let data = receiver.await.unwrap();
+    Ok(data)
 }
 
 /// Construct range header from start and length
@@ -42,7 +49,7 @@ pub fn range_from_end(length: u64) -> String {
 }
 
 /// Make range request on remote file
-pub async fn make_range_request(url: &str, start: u64, length: usize) -> Result<Vec<u8>, JsValue> {
+async fn _make_range_request(url: &str, start: u64, length: usize) -> Result<Vec<u8>, JsValue> {
     let mut opts = RequestInit::new();
     opts.method("GET");
     opts.mode(RequestMode::Cors);
@@ -58,6 +65,20 @@ pub async fn make_range_request(url: &str, start: u64, length: usize) -> Result<
     let resp: Response = resp_value.dyn_into().unwrap();
 
     Ok(resp_into_bytes(resp).await)
+}
+
+pub async fn make_range_request(
+    url: String,
+    start: u64,
+    length: usize,
+) -> Result<Vec<u8>, JsValue> {
+    let (sender, receiver) = oneshot::channel::<Vec<u8>>();
+    spawn_local(async move {
+        let inner_data = _make_range_request(&url, start, length).await.unwrap();
+        sender.send(inner_data).unwrap();
+    });
+    let data = receiver.await.unwrap();
+    Ok(data)
 }
 
 async fn resp_into_bytes(resp: Response) -> Vec<u8> {


### PR DESCRIPTION
Updates:

- Correctly handle a parquet fragment with a separate `url`. The `url` should be the **base** path
- Update `readRowGroupAsync` to take a _row group metadata_ instead of an index. This should make it easier to handle statistics and passing in a specific row group. It also means that manually passing in the arrow schema is also required.

Todo:

- Expose statistics from the struct to make it easier to filter on row groups.