### PR TITLE
Use reqwest for async apis (attempt 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,19 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compat"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b48b4ff0c2026db683dea961cd8ea874737f56cffca86fa84415eaddc51c00d"
-dependencies = [
- "futures-core",
- "futures-io",
- "once_cell",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,14 +969,12 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
- "futures",
  "num",
  "num-bigint",
  "parquet-format",
  "rand",
  "snap",
  "thrift",
- "tokio",
  "zstd",
 ]
 
@@ -1019,7 +1004,6 @@ version = "0.4.0-beta.5"
 dependencies = [
  "arrow",
  "arrow2",
- "async-compat",
  "bytes",
  "clap",
  "console_error_panic_hook",
@@ -1032,7 +1016,6 @@ dependencies = [
  "reqwest",
  "serde-wasm-bindgen",
  "thiserror",
- "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -1447,19 +1430,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "winapi",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "array-init-cursor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,24 +212,24 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "bytemuck"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5377c8865e74a160d21f29c2d40669f53286db6eab59b88540cbb12ffc8b835"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd2f4180c5721da6335cc9e9061cce522b87a35e51cc57636d28d22a9863c80"
+checksum = "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -256,14 +265,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "js-sys",
+ "iana-time-zone",
  "num-integer",
  "num-traits",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -317,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,9 +353,18 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -371,10 +394,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foreign_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1b05cbd864bcaecbd3455d6d967862d446e4ebfc3c2e5e5b9841e53cba6673"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -479,6 +517,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +578,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +684,12 @@ dependencies = [
  "async-trait",
  "futures-util",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itoa"
@@ -642,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "log"
@@ -657,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c038063f7a78126c539d666a0323a2032de5e7366012cd14a6eafc5ba290bbd6"
+checksum = "1a8cbbb2831780bc3b9c15a41f5b49222ef756b6730a95f3decfdd15903eb5a3"
 dependencies = [
  "twox-hash",
 ]
@@ -671,12 +816,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.5.3"
+name = "mime"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -787,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "ordered-float"
@@ -802,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parquet"
@@ -866,8 +1029,10 @@ dependencies = [
  "parquet",
  "parquet2",
  "range-reader",
+ "reqwest",
  "serde-wasm-bindgen",
  "thiserror",
+ "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -891,6 +1056,12 @@ dependencies = [
  "streaming-decompression",
  "zstd",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1016,6 +1187,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "reqwest"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,9 +1234,9 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -1049,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1060,10 +1265,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1097,6 +1314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "streaming-iterator"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4817bfdf8f0b576330b83b55bed0ec89204aa7da62c2fa11fad2119f33a70014"
+checksum = "0085b81d5d4e57f264d492641cf80ea508c96d9a0e47c6296e8f016504e28fd7"
 
 [[package]]
 name = "strsim"
@@ -1192,17 +1419,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.20.1"
+name = "tinyvec"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
  "autocfg",
  "bytes",
+ "libc",
  "memchr",
+ "mio",
  "once_cell",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "winapi",
 ]
 
 [[package]]
@@ -1217,6 +1463,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,16 +1519,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1376,6 +1704,58 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ arrow1 = ["dep:arrow", "dep:parquet", "dep:bytes"]
 arrow2 = ["dep:arrow2", "dep:parquet2", "dep:serde-wasm-bindgen"]
 reader = []
 writer = []
-async = ["dep:wasm-bindgen-futures", "dep:futures", "dep:range-reader"]
+async = ["dep:wasm-bindgen-futures", "dep:futures", "dep:range-reader", "dep:reqwest"]
 debug = ["console_error_panic_hook", "clap"]
 
 brotli = ["parquet?/brotli", "parquet2?/brotli"]
@@ -77,6 +77,12 @@ clap = { version = ">=3.1.15, <3.3", optional = true, features = ["derive"] }
 wasm-bindgen-futures = {version = "0.4.30", optional = true}
 futures = {version = "0.3", optional = true}
 range-reader = {version = "0.2", optional = true}
+reqwest = {version = "0.11.11", optional = true, default-features = false}
+
+# Unused but included to fix compilation errors
+# TODO: shouldn't need this
+tokio = {version = "*", default-features = false}
+
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,12 @@ arrow1 = ["dep:arrow", "dep:parquet", "dep:bytes"]
 arrow2 = ["dep:arrow2", "dep:parquet2", "dep:serde-wasm-bindgen"]
 reader = []
 writer = []
-async = ["dep:wasm-bindgen-futures", "dep:futures", "dep:range-reader", "dep:reqwest"]
+async = [
+  "dep:wasm-bindgen-futures",
+  "dep:futures",
+  "dep:range-reader",
+  "dep:reqwest",
+]
 debug = ["console_error_panic_hook", "clap"]
 
 brotli = ["parquet?/brotli", "parquet2?/brotli"]
@@ -33,10 +38,18 @@ lz4 = ["parquet2?/lz4_flex"]
 all_compressions = ["brotli", "gzip", "snappy", "zstd", "lz4"]
 
 # Full list of available features
-full = ["arrow1", "arrow2", "async", "debug", "all_compressions", "reader", "writer"]
+full = [
+  "arrow1",
+  "arrow2",
+  "async",
+  "debug",
+  "all_compressions",
+  "reader",
+  "writer",
+]
 
 [dependencies]
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"]  }
+wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -64,24 +77,18 @@ arrow = { version = "19.0", default-features = false, optional = true }
 parquet = { version = "19.0", default-features = false, optional = true, features = [
   "arrow",
   "base64",
-  "async",
 ] }
-async-compat = "0.2.1"
 bytes = { version = "1", optional = true }
 
-serde-wasm-bindgen = {version = "0.4.3", optional = true}
+serde-wasm-bindgen = { version = "0.4.3", optional = true }
 
 # 3.2 added deprecations that don't currently pass clippy
 clap = { version = ">=3.1.15, <3.3", optional = true, features = ["derive"] }
 
-wasm-bindgen-futures = {version = "0.4.30", optional = true}
-futures = {version = "0.3", optional = true}
-range-reader = {version = "0.2", optional = true}
-reqwest = {version = "0.11.11", optional = true, default-features = false}
-
-# Unused but included to fix compilation errors
-# TODO: shouldn't need this
-tokio = {version = "*", default-features = false}
+wasm-bindgen-futures = { version = "0.4.30", optional = true }
+futures = { version = "0.3", optional = true }
+range-reader = { version = "0.2", optional = true }
+reqwest = { version = "0.11.11", optional = true, default-features = false }
 
 
 [dependencies.web-sys]
@@ -94,7 +101,8 @@ features = [
   'RequestMode',
   'Response',
   'Window',
-  "Document", "Element"
+  "Document",
+  "Element",
 ]
 
 [dev-dependencies]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,6 +53,7 @@ wasm-pack build \
   --features reader \
   --features writer \
   --features all_compressions \
+  --features async \
   $FLAGS
 
 # Build web version into tmp_build/esm2

--- a/src/arrow2/reader_async.rs
+++ b/src/arrow2/reader_async.rs
@@ -6,7 +6,6 @@ use arrow2::io::ipc::write::{StreamWriter as IPCStreamWriter, WriteOptions as IP
 use arrow2::io::parquet::read::FileMetaData;
 use arrow2::io::parquet::read::{read_columns_many_async, RowGroupDeserializer};
 use futures::future::BoxFuture;
-// use parquet2::metadata::RowGroupMetaData;
 use arrow2::io::parquet::read::RowGroupMetaData;
 use parquet2::read::read_metadata_async as _read_metadata_async;
 use range_reader::{RangeOutput, RangedAsyncReader};

--- a/src/arrow2/reader_async.rs
+++ b/src/arrow2/reader_async.rs
@@ -4,9 +4,9 @@ use crate::common::fetch::{get_content_length, make_range_request};
 use arrow2::datatypes::Schema;
 use arrow2::io::ipc::write::{StreamWriter as IPCStreamWriter, WriteOptions as IPCWriteOptions};
 use arrow2::io::parquet::read::FileMetaData;
+use arrow2::io::parquet::read::RowGroupMetaData;
 use arrow2::io::parquet::read::{read_columns_many_async, RowGroupDeserializer};
 use futures::future::BoxFuture;
-use arrow2::io::parquet::read::RowGroupMetaData;
 use parquet2::read::read_metadata_async as _read_metadata_async;
 use range_reader::{RangeOutput, RangedAsyncReader};
 

--- a/src/arrow2/wasm.rs
+++ b/src/arrow2/wasm.rs
@@ -148,6 +148,7 @@ pub fn read_row_group(
 #[cfg(all(feature = "reader", feature = "async"))]
 pub async fn read_metadata_async(
     url: String,
+    // TODO: can this length be optional?
     content_length: usize,
 ) -> WasmResult<crate::arrow2::metadata::FileMetaData> {
     let metadata = crate::arrow2::reader_async::read_metadata_async(url, content_length).await?;
@@ -176,7 +177,7 @@ pub async fn read_metadata_async(
 /// for (let i = 0; i < parquetFileMetaData.numRowGroups(); i++) {
 ///   // IMPORTANT: For now, calling `copy()` on the metadata object is required whenever passing in to
 ///   // a function. Hopefully this can be resolved in the future sometime
-///   const rowGroupPromise = wasm.readRowGroupAsync2(url, length, parquetFileMetaData.copy(), i);
+///   const rowGroupPromise = wasm.readRowGroupAsync(url, metadata.copy().rowGroup(i));
 ///   promises.push(rowGroupPromise);
 /// }
 ///
@@ -191,6 +192,8 @@ pub async fn read_metadata_async(
 /// @param meta {@linkcode FileMetaData} from a call to {@linkcode readMetadata}
 /// @param i Number index of the row group to load
 /// @returns Uint8Array containing Arrow data in [IPC Stream format](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format). To parse this into an Arrow table, pass to `tableFromIPC` in the Arrow JS bindings.
+
+// TODO: update these docs!
 #[wasm_bindgen(js_name = readRowGroupAsync)]
 #[cfg(all(feature = "reader", feature = "async"))]
 pub async fn read_row_group_async(

--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 
 /// Get content-length of file
-pub async fn _get_content_length(url: String) -> Result<usize, JsValue> {
+pub async fn _get_content_length(url: String) -> Result<usize, reqwest::Error> {
     let client = reqwest::Client::new();
     let resp = client.head(url).send().await?;
     Ok(resp.content_length().unwrap().try_into().unwrap())
@@ -36,7 +36,11 @@ pub fn range_from_end(length: u64) -> String {
 }
 
 /// Make range request on remote file
-async fn _make_range_request(url: &str, start: u64, length: usize) -> Result<Vec<u8>, JsValue> {
+async fn _make_range_request(
+    url: &str,
+    start: u64,
+    length: usize,
+) -> Result<Vec<u8>, reqwest::Error> {
     let client = reqwest::Client::new();
     let range_str = range_from_start_and_length(start, length as u64);
     let resp = client

--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -1,27 +1,15 @@
+use std::convert::TryInto;
+
 use futures::channel::oneshot;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use wasm_bindgen_futures::JsFuture;
-use web_sys::{Request, RequestInit, RequestMode, Response};
 
 use wasm_bindgen_futures::spawn_local;
 
 /// Get content-length of file
 pub async fn _get_content_length(url: String) -> Result<usize, JsValue> {
-    let mut opts = RequestInit::new();
-    opts.method("HEAD");
-    opts.mode(RequestMode::Cors);
-
-    let request = Request::new_with_str_and_init(&url, &opts)?;
-    let window = web_sys::window().unwrap();
-
-    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
-    let resp: Response = resp_value.dyn_into().unwrap();
-
-    let length = resp.headers().get("content-length")?;
-    let a = length.unwrap();
-    let length_int = a.parse::<usize>().unwrap();
-    Ok(length_int)
+    let client = reqwest::Client::new();
+    let resp = client.head(url).send().await?;
+    Ok(resp.content_length().unwrap().try_into().unwrap())
 }
 
 pub async fn get_content_length(url: String) -> Result<usize, JsValue> {
@@ -50,21 +38,15 @@ pub fn range_from_end(length: u64) -> String {
 
 /// Make range request on remote file
 async fn _make_range_request(url: &str, start: u64, length: usize) -> Result<Vec<u8>, JsValue> {
-    let mut opts = RequestInit::new();
-    opts.method("GET");
-    opts.mode(RequestMode::Cors);
-
-    let request = Request::new_with_str_and_init(url, &opts)?;
-
-    request
-        .headers()
-        .set("Range", &range_from_start_and_length(start, length as u64))?;
-
-    let window = web_sys::window().unwrap();
-    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
-    let resp: Response = resp_value.dyn_into().unwrap();
-
-    Ok(resp_into_bytes(resp).await)
+    let client = reqwest::Client::new();
+    let range_str = range_from_start_and_length(start, length as u64);
+    let resp = client
+        .get(url)
+        .header("Range", range_str)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(resp.bytes().await?.to_vec())
 }
 
 pub async fn make_range_request(
@@ -79,13 +61,4 @@ pub async fn make_range_request(
     });
     let data = receiver.await.unwrap();
     Ok(data)
-}
-
-async fn resp_into_bytes(resp: Response) -> Vec<u8> {
-    let array_buffer_promise = JsFuture::from(resp.array_buffer().unwrap());
-    let array_buffer: JsValue = array_buffer_promise
-        .await
-        .expect("Could not get ArrayBuffer from file");
-
-    js_sys::Uint8Array::new(&array_buffer).to_vec()
 }

--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -1,8 +1,8 @@
 use std::convert::TryInto;
 
 use futures::channel::oneshot;
+use reqwest::header::{HeaderValue, RANGE};
 use wasm_bindgen::prelude::*;
-
 use wasm_bindgen_futures::spawn_local;
 
 /// Get content-length of file
@@ -42,7 +42,7 @@ async fn _make_range_request(url: &str, start: u64, length: usize) -> Result<Vec
     let range_str = range_from_start_and_length(start, length as u64);
     let resp = client
         .get(url)
-        .header("Range", range_str)
+        .header(RANGE, HeaderValue::from_str(range_str.as_str()))
         .send()
         .await?
         .error_for_status()?;

--- a/src/common/fetch.rs
+++ b/src/common/fetch.rs
@@ -1,7 +1,6 @@
 use std::convert::TryInto;
 
 use futures::channel::oneshot;
-use reqwest::header::{HeaderValue, RANGE};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 
@@ -42,7 +41,7 @@ async fn _make_range_request(url: &str, start: u64, length: usize) -> Result<Vec
     let range_str = range_from_start_and_length(start, length as u64);
     let resp = client
         .get(url)
-        .header(RANGE, HeaderValue::from_str(range_str.as_str()))
+        .header("Range", range_str)
         .send()
         .await?
         .error_for_status()?;

--- a/www/async_testing.js
+++ b/www/async_testing.js
@@ -1,29 +1,37 @@
 import * as arrow from "@apache-arrow/es2015-cjs/Arrow.dom";
-import * as wasm from "parquet-wasm/bundler/arrow2";
+import * as wasm from "parquet-wasm/arrow2";
 
 wasm.setPanicHook();
 window.wasm = wasm;
 // const url = 'https://raw.githubusercontent.com/opengeospatial/geoparquet/main/examples/example.parquet';
-const url = 'https://raw.githubusercontent.com/kylebarron/parquet-wasm/main/tests/data/2-partition-brotli.parquet';
+const url =
+  "https://raw.githubusercontent.com/kylebarron/parquet-wasm/main/tests/data/2-partition-brotli.parquet";
 window.url = url;
 
 async function main() {
-  console.log('hello world');
-  const resp = await fetch(url, {method: 'HEAD'});
-  const length = parseInt(resp.headers.get('Content-Length'));
+  console.log("hello world");
+  const resp = await fetch(url, { method: "HEAD" });
+  const length = parseInt(resp.headers.get("Content-Length"));
 
-  const metadata = await wasm.readMetadataAsync2(url, length);
+  const metadata = await wasm.readMetadataAsync(url, length);
+  const arrowSchema = metadata.arrowSchema();
 
   // Read all batches from the file in parallel
   const promises = [];
   for (let i = 0; i < metadata.numRowGroups(); i++) {
-    const rowGroupPromise = wasm.readRowGroupAsync2(url, length, metadata.copy(), i);
+    const rowGroupPromise = wasm.readRowGroupAsync(
+      url,
+      metadata.copy().rowGroup(i),
+      arrowSchema.copy()
+    );
     promises.push(rowGroupPromise);
   }
 
   const recordBatchChunks = await Promise.all(promises);
+  const tables = recordBatchChunks.map(arrow.tableFromIPC);
+  console.log('tables', tables)
 
-  const table = new arrow.Table(recordBatchChunks);
+  const table = new arrow.Table(tables);
   window.table = table;
   console.log("table", table);
 


### PR DESCRIPTION
It turns out the issues around 
```
error: Only features sync,macros,io-util,rt,time are supported on wasm.
   --> /Users/kyle/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.21.0/src/lib.rs:462:1
    |
462 | compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
were coming from unused arrow1 apis

supersedes https://github.com/kylebarron/parquet-wasm/pull/201, closes https://github.com/kylebarron/parquet-wasm/issues/200