### PR TITLE
zstd features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "zstd-sys",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ range-reader = { version = "0.2", optional = true }
 reqwest = { version = "0.11.12", optional = true, default-features = false }
 
 # Pass "wasm" and "thin" down to the transitive zstd dependency
-zstd = { features = ["wasm", "thin"], default-features = false }
+zstd = { version = "*", features = ["wasm", "thin"], default-features = false }
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = ["console_error_panic_hook", "clap"]
 brotli = ["parquet?/brotli", "parquet2?/brotli"]
 gzip = ["parquet?/flate2", "parquet2?/gzip"]
 snappy = ["parquet?/snap", "parquet2?/snappy"]
-zstd = ["parquet?/zstd", "parquet2?/zstd", "dep:zstd-sys"]
+zstd = ["parquet?/zstd", "parquet2?/zstd"]
 # LZ4 not yet supported on parquet crate
 lz4 = ["parquet2?/lz4_flex"]
 
@@ -92,8 +92,8 @@ futures = { version = "0.3", optional = true }
 range-reader = { version = "0.2", optional = true }
 reqwest = { version = "0.11.12", optional = true, default-features = false }
 
-# We have to pin zstd-sys because of https://github.com/gyscos/zstd-rs/issues/205
-zstd-sys = { version = "=2.0.1", optional = true, default-features = false }
+# Pass "wasm" and "thin" down to the transitive zstd dependency
+zstd = { features = ["wasm", "thin"], default-features = false }
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ debug = ["console_error_panic_hook", "clap"]
 brotli = ["parquet?/brotli", "parquet2?/brotli"]
 gzip = ["parquet?/flate2", "parquet2?/gzip"]
 snappy = ["parquet?/snap", "parquet2?/snappy"]
-zstd = ["parquet?/zstd", "parquet2?/zstd"]
+zstd = ["parquet?/zstd", "parquet2?/zstd", "dep:zstd"]
 # LZ4 not yet supported on parquet crate
 lz4 = ["parquet2?/lz4_flex"]
 
@@ -93,7 +93,7 @@ range-reader = { version = "0.2", optional = true }
 reqwest = { version = "0.11.12", optional = true, default-features = false }
 
 # Pass "wasm" and "thin" down to the transitive zstd dependency
-zstd = { version = "*", features = ["wasm", "thin"], default-features = false }
+zstd = { version = "*", features = ["wasm", "thin"], default-features = false, optional = true }
 
 [dependencies.web-sys]
 version = "0.3.4"


### PR DESCRIPTION
It looks like the `import env` issue from https://github.com/gyscos/zstd-rs/issues/205 is actually fixed by passing `wasm` and `thin` to zstd

From https://github.com/kylebarron/parquet-wasm/pull/271/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R115-R120