### PR TITLE
Streaming Writes implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ async = [
   "dep:async-compat",
   "dep:async-stream",
   "parquet?/async",
+  "parquet2?/async",
 ]
 debug = ["console_error_panic_hook", "clap"]
 

--- a/src/arrow2/mod.rs
+++ b/src/arrow2/mod.rs
@@ -20,4 +20,7 @@ pub mod writer;
 #[cfg(feature = "writer")]
 pub mod writer_properties;
 
+#[cfg(all(feature = "writer", feature = "async"))]
+pub mod writer_async;
+
 pub mod error;

--- a/src/arrow2/wasm.rs
+++ b/src/arrow2/wasm.rs
@@ -229,3 +229,18 @@ pub async fn read_parquet_stream(
         .map(|batch| Ok(batch.into()));
     Ok(wasm_streams::ReadableStream::from_stream(stream).into_raw())
 }
+
+#[wasm_bindgen(js_name = "writeParquetStream")]
+#[cfg(all(feature = "writer", feature = "async"))]
+pub fn write_parquet_stream(
+    table: Table,
+    writer_properties: Option<crate::arrow2::writer_properties::WriterProperties>,
+) -> WasmResult<wasm_streams::readable::sys::ReadableStream> {
+    let (schema, chunks) = table.into_inner();
+    let output_stream = super::writer_async::write_record_batches_to_stream(
+        chunks.into_iter(),
+        schema,
+        writer_properties.unwrap_or_default(),
+    );
+    Ok(output_stream?)
+}

--- a/src/arrow2/writer_async.rs
+++ b/src/arrow2/writer_async.rs
@@ -1,0 +1,72 @@
+use crate::arrow2::error::Result;
+use arrow2::array::Array;
+use arrow2::chunk::Chunk;
+use arrow2::datatypes::Schema;
+use arrow2::io::parquet::write::FileSink;
+use futures::{AsyncWrite, SinkExt};
+use wasm_bindgen_futures::spawn_local;
+
+struct WrappedWritableStream<'writer> {
+    stream: wasm_streams::writable::IntoAsyncWrite<'writer>,
+}
+
+impl<'writer> AsyncWrite for WrappedWritableStream<'writer> {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        AsyncWrite::poll_write(std::pin::Pin::new(&mut self.get_mut().stream), cx, buf)
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        AsyncWrite::poll_flush(std::pin::Pin::new(&mut self.get_mut().stream), cx)
+    }
+
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        AsyncWrite::poll_close(std::pin::Pin::new(&mut self.get_mut().stream), cx)
+    }
+}
+
+unsafe impl<'writer> Send for WrappedWritableStream<'writer> {}
+
+pub fn write_record_batches_to_stream(
+    chunks: impl Iterator<Item = Chunk<Box<dyn Array>>> + 'static,
+    schema: Schema,
+    writer_properties: crate::arrow2::writer_properties::WriterProperties,
+) -> Result<wasm_streams::readable::sys::ReadableStream> {
+    let options = writer_properties.get_write_options();
+    let encoding = writer_properties.get_encoding();
+    // Need to create an encoding for each column
+    let mut encodings = vec![];
+    for _ in &schema.fields {
+        // Note, the nested encoding is for nested Parquet columns
+        // Here we assume columns are not nested
+        encodings.push(vec![encoding]);
+    }
+
+    let (writable_stream, output_stream) = {
+        let raw_stream = wasm_streams::transform::sys::TransformStream::new();
+        let raw_writable = raw_stream.writable();
+        let inner_writer = wasm_streams::WritableStream::from_raw(raw_writable).into_async_write();
+        let writable_stream = WrappedWritableStream {
+            stream: inner_writer,
+        };
+        (writable_stream, raw_stream.readable())
+    };
+
+    spawn_local::<_>(async move {
+        let mut writer = FileSink::try_new(writable_stream, schema, encodings, options).unwrap();
+        for chunk in chunks {
+            let _result = writer.send(chunk).await;
+        }
+        let _ = writer.close().await;
+    });
+    Ok(output_stream)
+}

--- a/tests/js/arrow2.ts
+++ b/tests/js/arrow2.ts
@@ -106,3 +106,17 @@ test("iterate over row groups", (t) => {
 
   t.end();
 });
+
+test("read-write stream-read round trip (no writer properties provided)", async (t) => {
+  const expectedTable = readExpectedArrowData();
+
+  const dataPath = `${dataDir}/1-partition-brotli.parquet`;
+  const buffer = readFileSync(dataPath);
+  const arr = new Uint8Array(buffer);
+  const table = wasm.readParquet(arr);
+  const stream = await wasm.writeParquetStream(table);
+  const accumulatedBuffer = new Uint8Array(await new Response(stream).arrayBuffer());
+  const roundtripTable = tableFromIPC(wasm.readParquet(accumulatedBuffer).intoIPC());
+
+  testArrowTablesEqual(t, expectedTable, roundtripTable);
+})


### PR DESCRIPTION
The interface for writing to streams so far is:
```typescript
const table = wasm.readParquet(buf);
const outputStream = wasm.writeParquetStream(table);
// sink the contents somewhere useful, like to a server that supports streaming POST requests.
await fetch(url, {
  method: 'POST',
  body: outputStream,
  duplex: 'half',
});

// or perhaps to the filesystem
const writableStream = await fileHandle.createWritable();
await outputStream.pipeTo(writableStream); // 🤯
```

I suspect it won't take *that* much to get this to take an FFI table (do we need `unsafe impl From<FFITable> for Table` in the arrow-wasm repo for that?).

What I'd really like this to do is close the loop on a workflow similar to:
```mermaid

flowchart LR
    subgraph geoarrow["Bunch of geoarrow transforms"]
    direction TB
    op0["op(batch)"] -.-> opn["op(batch)"]
    end
    A[FS] -->|"readParquetStream"| B("Stream&lt;RecordBatch&gt;") --> geoarrow
    geoarrow -->|"writeParquetStream"| C[FS]
```
Just taking a table is only _somewhat_ useful (you still have to keep the batches that make up the table in memory until the write stream finishes), and tbh is mostly a placeholder until I figure out JsCast properly.

A few design questions come to mind:
1. The writer_async function(s) always return ReadableStreams - is there any appetite for doing stuff to the parquet bytes before they cross the WASM<->JS boundary? The only thing I can really think of is streaming checksums.

This definitely needs a variant that takes a rust stream of RecordBatches (similar to the read functions), in part to avoid the cost of bouncing pointers out to JS, but much more importantly, remove a lot of JS-side orchestration. It's still subject to the above proviso (the output is always a ReadableStream, since the only real place to direct the output is to IO of some form).