### PR TITLE
CI production build size summary

### DIFF
--- a/.github/workflows/pr-manipulation.yml
+++ b/.github/workflows/pr-manipulation.yml
@@ -35,8 +35,22 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
       - run: unzip pr.zip
 
-      - name: Comment PR with summary output
-        uses: thollander/actions-comment-pull-request@v2
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3
         with:
-          filePath: step_summary.md
-          comment_tag: execution
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const issueNumber = Number(fs.readFileSync('./NR'));
+            const summaryContent = fs.readFileSync('./step_summary.md', 'utf-8');
+            const existingCommentsOpts = github.issues.listComments({...context.repo, issue_number: issueNumber});
+            const existingComments = await github.paginate(existingCommentsOpts);
+            const TAG = 'execution';
+            const tagPattern = `<!-- pr_asset_summary_comment "${TAG}" -->`;
+            const body = `${summaryContent}\n${tagPattern}`;
+            const preExistingComment = existingComments.find((comment) => comment.body.includes(tagPattern));
+            if(preExistingComment) {
+              await github.issues.updateComment({ ...context.repo, comment_id: preExistingComment.id, body });
+            } else {
+              await github.issues.createComment({ ...context.repo, issue_number: issueNumber, body });
+            }

--- a/.github/workflows/pr-manipulation.yml
+++ b/.github/workflows/pr-manipulation.yml
@@ -17,24 +17,23 @@ jobs:
         uses: actions/github-script@v3.1.0
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
+            const fs = require('fs');
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+              ...context.repo,
+              run_id: ${{github.event.workflow_run.id }},
             });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
-            var download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+            const download = await github.actions.downloadArtifact({
+              ...context.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
             });
-            var fs = require('fs');
+            
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
       - run: unzip pr.zip
-
+      
       - name: 'Comment on PR'
         uses: actions/github-script@v3
         with:
@@ -43,6 +42,7 @@ jobs:
             const fs = require('fs');
             const issueNumber = Number(fs.readFileSync('./NR'));
             const summaryContent = fs.readFileSync('./step_summary.md', 'utf-8');
+
             const existingCommentsOpts = github.issues.listComments.endpoint.merge({
               ...context.repo, issue_number: issueNumber
             });

--- a/.github/workflows/pr-manipulation.yml
+++ b/.github/workflows/pr-manipulation.yml
@@ -1,0 +1,42 @@
+name: PR Comment Generation
+
+on:
+  workflow_run:
+    workflows: ["Build and Test"]
+    types:
+      - completed
+
+jobs:
+  comment_on_pr:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: Comment PR with summary output
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: step_summary.md
+          comment_tag: execution

--- a/.github/workflows/pr-manipulation.yml
+++ b/.github/workflows/pr-manipulation.yml
@@ -43,12 +43,14 @@ jobs:
             const fs = require('fs');
             const issueNumber = Number(fs.readFileSync('./NR'));
             const summaryContent = fs.readFileSync('./step_summary.md', 'utf-8');
-            const existingCommentsOpts = github.issues.listComments({...context.repo, issue_number: issueNumber});
+            const existingCommentsOpts = github.issues.listComments.endpoint.merge({
+              ...context.repo, issue_number: issueNumber
+            });
             const existingComments = await github.paginate(existingCommentsOpts);
             const TAG = 'execution';
             const tagPattern = `<!-- pr_asset_summary_comment "${TAG}" -->`;
             const body = `${summaryContent}\n${tagPattern}`;
-            const preExistingComment = existingComments.find((comment) => comment.body.includes(tagPattern));
+            const preExistingComment = existingComments.find((comment) => comment.body?.includes(tagPattern));
             if(preExistingComment) {
               await github.issues.updateComment({ ...context.repo, comment_id: preExistingComment.id, body });
             } else {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,9 +123,9 @@ jobs:
         run: yarn build
       - name: Size Reporting
         run: |
-          ARROW1_SIZE=$(cat pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null)
+          ARROW1_SIZE=$(cat pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null | tr -d '\n')
           brotli -Z pkg/esm/arrow1_bg.wasm
-          ARROW1_BR_SIZE=$(cat pkg/esm/arrow1_bg.wasm.br | pv -f -b 2>&1 >/dev/null)
+          ARROW1_BR_SIZE=$(cat pkg/esm/arrow1_bg.wasm.br | pv -f -b 2>&1 >/dev/null | tr -d '\n')
           echo $ARROW1_SIZE
           echo $ARROW1_BR_SIZE
           echo "| Asset  | Size |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,8 +131,9 @@ jobs:
             COMPRESSED_SIZE=$(cat "${asset}.br" | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
             echo "| ${asset} | $SIZE | $COMPRESSED_SIZE |" >> $GITHUB_STEP_SUMMARY
           done;
-      - name: Comment PR with execution number
+          cp $GITHUB_STEP_SUMMARY fixed_output.md
+      - name: Comment PR with summary output
         uses: thollander/actions-comment-pull-request@v2
         with:
-          filePath: $GITHUB_STEP_SUMMARY
+          filePath: fixed_output.md
           comment_tag: execution

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,3 +114,36 @@ jobs:
 
       - name: "clippy --all"
         run: cargo clippy --all --features=full --tests -- -D warnings
+
+  node-build-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            profile: minimal
+            override: true
+
+      - name: Install
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build bundle
+        run: yarn build
+      - name: Size Reporting
+        run: |
+          ARROW1_SIZE=$(cat pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null)
+          ARROW1_BR_SIZE=$(brotli -Z -c pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null)
+          echo "| Asset  | Size |" >> $GITHUB_STEP_SUMMARY
+          echo "| ------ | ---- |" >> $GITHUB_STEP_SUMMARY
+          echo "| pkg/esm/arrow1_bg.wasm | $ARROW_SIZE |" >> $GITHUB_STEP_SUMMARY
+          echo "| pkg/esm/arrow1_bg.wasm.br | $ARROW1_BR_SIZE |" >> $GITHUB_STEP_SUMMARY
+        # TODO: matrix equivalent of this / and/or use the @actions/core npm package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,21 +116,18 @@ jobs:
           node-version: "20"
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: brotli pv
+          packages: brotli pv parallel
           version: 1.0
 
       - name: Build bundle
         run: yarn build
       - name: Size Reporting
         run: |
-          ARROW1_SIZE=$(cat pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
-          brotli -Z pkg/esm/arrow1_bg.wasm
-          ARROW1_BR_SIZE=$(cat pkg/esm/arrow1_bg.wasm.br | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
-          echo $ARROW1_SIZE
-          echo $ARROW1_BR_SIZE
-          echo "| Asset  | Size |" >> $GITHUB_STEP_SUMMARY
-          echo "| ------ | ---- |" >> $GITHUB_STEP_SUMMARY
-          echo "| pkg/esm/arrow1_bg.wasm | $ARROW1_SIZE |" >> $GITHUB_STEP_SUMMARY
-          echo "| pkg/esm/arrow1_bg.wasm.br | $ARROW1_BR_SIZE |" >> $GITHUB_STEP_SUMMARY
-          cat $GITHUB_STEP_SUMMARY
-        # TODO: matrix equivalent of this / and/or use the @actions/core npm package
+          ls pkg/*/*.wasm | parallel brotli -f -Z {}
+          echo "| Asset  | Size | Compressed Size |" >> $GITHUB_STEP_SUMMARY
+          echo "| ------ | ---- | --------------- |" >> $GITHUB_STEP_SUMMARY
+          for asset in $(ls pkg/*/*.wasm); do
+            SIZE=$(cat $asset | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
+            COMPRESSED_SIZE=$(cat "${asset}.br" | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
+            echo "| ${asset} | $SIZE | $COMPRESSED_SIZE |" >> $GITHUB_STEP_SUMMARY
+          done;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,9 +131,10 @@ jobs:
             COMPRESSED_SIZE=$(cat "${asset}.br" | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
             echo "| ${asset} | $SIZE | $COMPRESSED_SIZE |" >> $GITHUB_STEP_SUMMARY
           done;
-          cp $GITHUB_STEP_SUMMARY fixed_output.md
-      - name: Comment PR with summary output
-        uses: thollander/actions-comment-pull-request@v2
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          cp $GITHUB_STEP_SUMMARY ./pr/step_summary.md
+      - uses: actions/upload-artifact@v2
         with:
-          filePath: fixed_output.md
-          comment_tag: execution
+          name: pr
+          path: pr/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: brotli pv
+          version: 1.0
 
       - name: Build bundle
         run: yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,14 +120,14 @@ jobs:
           version: 1.0
 
       - name: Build bundle
-        run: yarn build
+        run: ./scripts/report_build.sh
       - name: Size Reporting
         run: |
-          ls pkg/*/*.wasm | parallel brotli -f -Z {}
+          ls report_pkg/*/*.wasm | parallel brotli -f -Z {}
           mkdir -p ./pr
           echo "| Asset  | Size | Compressed Size |" >> ./pr/step_summary.md
           echo "| ------ | ---- | --------------- |" >> ./pr/step_summary.md
-          for asset in $(ls pkg/*/*.wasm); do
+          for asset in $(ls report_pkg/*/*.wasm); do
             export SIZE=$(stat --format '%s' $asset)
             export COMPRESSED_SIZE=$(stat --format '%s' "${asset}.br")
             export asset

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,3 +131,8 @@ jobs:
             COMPRESSED_SIZE=$(cat "${asset}.br" | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
             echo "| ${asset} | $SIZE | $COMPRESSED_SIZE |" >> $GITHUB_STEP_SUMMARY
           done;
+      - name: Comment PR with execution number
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: $GITHUB_STEP_SUMMARY
+          comment_tag: execution

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
           node-version: "20"
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: brotli pv parallel
+          packages: brotli pv parallel jq
           version: 1.0
 
       - name: Build bundle
@@ -124,16 +124,124 @@ jobs:
       - name: Size Reporting
         run: |
           ls pkg/*/*.wasm | parallel brotli -f -Z {}
-          echo "| Asset  | Size | Compressed Size |" >> $GITHUB_STEP_SUMMARY
-          echo "| ------ | ---- | --------------- |" >> $GITHUB_STEP_SUMMARY
-          for asset in $(ls pkg/*/*.wasm); do
-            SIZE=$(cat $asset | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
-            COMPRESSED_SIZE=$(cat "${asset}.br" | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
-            echo "| ${asset} | $SIZE | $COMPRESSED_SIZE |" >> $GITHUB_STEP_SUMMARY
-          done;
           mkdir -p ./pr
+          echo "| Asset  | Size | Compressed Size |" >> ./pr/step_summary.md
+          echo "| ------ | ---- | --------------- |" >> ./pr/step_summary.md
+          for asset in $(ls pkg/*/*.wasm); do
+            export SIZE=$(stat --format '%s' $asset)
+            export COMPRESSED_SIZE=$(stat --format '%s' "${asset}.br")
+            export asset
+            echo "| ${asset} | $(echo $SIZE | numfmt --to=si --suffix="B") | $(echo $COMPRESSED_SIZE | numfmt --to=si --suffix="B") |" >> ./pr/step_summary.md
+            echo $(jq -n '{"asset": $ENV.asset, "size": $ENV.SIZE | tonumber, "compressed_size": $ENV.COMPRESSED_SIZE | tonumber}')
+          done | jq -s 'map({ (.asset|tostring): .}) | add' > ./pr/asset_manifest.json
           echo ${{ github.event.number }} > ./pr/NR
-          cp $GITHUB_STEP_SUMMARY ./pr/step_summary.md
+          if [[ "${{ github.event_type }}" != "pull_request" ]]; then
+            cat ./pr/step_summary.md > $GITHUB_STEP_SUMMARY
+          fi;
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
+  delta_generation:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request'
+    needs: node-build-report
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: pr
+          path: pr/
+      - name: 'Download artifact'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+            const baseContext = {
+              repo: {
+                repo: '${{ github.event.pull_request.base.repo.name }}',
+                owner: '${{ github.event.pull_request.base.repo.owner.login }}'
+              }
+            };
+            const baseWorkflows = await github.rest.actions.listWorkflowRuns({
+              ...baseContext.repo,
+              branch: '${{ github.event.pull_request.base.ref }}',
+              status: 'success',
+              workflow_id: 'test.yml',
+            });
+            const matchWorkflow = baseWorkflows.data?.workflow_runs?.[0];
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              ...baseContext.repo,
+              run_id: matchWorkflow?.id,
+            });
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            const download = await github.rest.actions.downloadArtifact({
+              ...baseContext.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+              
+            fs.writeFileSync('${{github.workspace}}/base.zip', Buffer.from(download.data));
+            execSync(`unzip -p base.zip asset_manifest.json >base_asset_manifest.json || true`);
+            // now, read in the asset manifests, for the head and base
+            let baseAssets = {};
+            try {
+              baseAssets = JSON.parse(fs.readFileSync('./base_asset_manifest.json'));
+            } catch (error) {
+              console.log('No base asset manifest found');
+            }
+            const assets = JSON.parse(fs.readFileSync('./pr/asset_manifest.json'));
+            const unitOptions = {
+                style: 'unit', unit: 'byte', unitDisplay: 'narrow', notation: 'compact',
+                maximumSignificantDigits: 3
+            };
+            const formatter = new Intl.NumberFormat('en-US', unitOptions);
+            const signedFormatter = new Intl.NumberFormat('en-US', { ...unitOptions, signDisplay: 'always' });
+            const percentFormatter = Intl.NumberFormat('en-US', { style: 'percent', signDisplay: 'always' });
+            const colorMap = {
+                '-1': 'green',
+                1: 'red',
+                0: 'black',
+                NaN: 'black'
+            };
+            // compute deltas and output markdown fragments
+            const lineFragments = Object.entries(assets).map(([k, v]) => {
+                const baseAsset = baseAssets[k] ?? {};
+                const { asset, size, compressed_size, size_delta, compressed_size_delta } = {
+                    ...v,
+                    ...Object.fromEntries(['size', 'compressed_size'].map(subK => {
+                        // compute the percentage change, NaN if the asset wasn't available
+                        const proportionalDelta = 1 - v?.[subK] / baseAsset?.[subK];
+                        const absoluteDelta = baseAsset?.[subK] - v?.[subK]
+                        const sign = Math.sign(proportionalDelta);
+                        // conditionally color the output via an inline latex block
+                        let fragment = '';
+                        if(Number.isFinite(proportionalDelta)) {
+                            fragment = `${signedFormatter.format(absoluteDelta)} ${percentFormatter.format(proportionalDelta)}`;
+                        } else {
+                            fragment = 'N/A';
+                        }
+                        if(!Number.isFinite(proportionalDelta) || sign === 0) {
+                          return [`${subK}_delta`, fragment]
+                        } else {
+                          const formattedFragment = `$\\color{${colorMap[sign]}}\\text{${fragment.replace('%', '\\%')}}$`;
+                          return [`${subK}_delta`, formattedFragment]
+                        }
+                    }))
+                };
+                // output a markdown fragment
+                const sizeFragment = `${formatter.format(size)} ${size_delta}`
+                const compressedFragment = `${formatter.format(compressed_size)} ${compressed_size_delta}`
+                return [asset, sizeFragment, compressedFragment]
+            });
+            await core.summary.addHeading('Asset Sizes').addTable([
+              [{data: 'Asset', header: true}, {data: 'Uncompressed Size', header: true}, {data: 'Compressed Size', header: true}],
+              ...lineFragments
+            ]).write();
+            fs.cpSync(process.env.GITHUB_STEP_SUMMARY, './pr/step_summary.md')
       - uses: actions/upload-artifact@v2
         with:
           name: pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,9 +123,9 @@ jobs:
         run: yarn build
       - name: Size Reporting
         run: |
-          ARROW1_SIZE=$(cat pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null | tr -d '\n')
+          ARROW1_SIZE=$(cat pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
           brotli -Z pkg/esm/arrow1_bg.wasm
-          ARROW1_BR_SIZE=$(cat pkg/esm/arrow1_bg.wasm.br | pv -f -b 2>&1 >/dev/null | tr -d '\n')
+          ARROW1_BR_SIZE=$(cat pkg/esm/arrow1_bg.wasm.br | pv -f -b 2>&1 >/dev/null | tr -d '\n\r')
           echo $ARROW1_SIZE
           echo $ARROW1_BR_SIZE
           echo "| Asset  | Size |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,5 +132,5 @@ jobs:
           echo "| ------ | ---- |" >> $GITHUB_STEP_SUMMARY
           echo "| pkg/esm/arrow1_bg.wasm | $ARROW1_SIZE |" >> $GITHUB_STEP_SUMMARY
           echo "| pkg/esm/arrow1_bg.wasm.br | $ARROW1_BR_SIZE |" >> $GITHUB_STEP_SUMMARY
-          echo $GITHUB_STEP_SUMMARY
+          cat $GITHUB_STEP_SUMMARY
         # TODO: matrix equivalent of this / and/or use the @actions/core npm package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+            targets: wasm32-unknown-unknown
 
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -138,7 +140,7 @@ jobs:
           if [[ "${{ github.event_type }}" != "pull_request" ]]; then
             cat ./pr/step_summary.md > $GITHUB_STEP_SUMMARY
           fi;
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/
@@ -148,7 +150,7 @@ jobs:
       github.event_name == 'pull_request'
     needs: node-build-report
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: pr
           path: pr/
@@ -178,14 +180,16 @@ jobs:
             const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
-            const download = await github.rest.actions.downloadArtifact({
-              ...baseContext.repo,
-              artifact_id: matchArtifact.id,
-              archive_format: 'zip',
-            });
-              
-            fs.writeFileSync('${{github.workspace}}/base.zip', Buffer.from(download.data));
-            execSync(`unzip -p base.zip asset_manifest.json >base_asset_manifest.json || true`);
+            if(matchArtifact) {
+              const download = await github.rest.actions.downloadArtifact({
+                ...baseContext.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+                
+              fs.writeFileSync('${{github.workspace}}/base.zip', Buffer.from(download.data));
+              execSync(`unzip -p base.zip asset_manifest.json >base_asset_manifest.json || true`);
+            } 
             // now, read in the asset manifests, for the head and base
             let baseAssets = {};
             try {
@@ -242,7 +246,7 @@ jobs:
               ...lineFragments
             ]).write();
             fs.cpSync(process.env.GITHUB_STEP_SUMMARY, './pr/step_summary.md')
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,8 +146,10 @@ jobs:
         run: |
           ARROW1_SIZE=$(cat pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null)
           ARROW1_BR_SIZE=$(brotli -Z -c pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null)
+          echo $ARROW1_SIZE
+          echo $ARROW1_BR_SIZE
           echo "| Asset  | Size |" >> $GITHUB_STEP_SUMMARY
           echo "| ------ | ---- |" >> $GITHUB_STEP_SUMMARY
-          echo "| pkg/esm/arrow1_bg.wasm | $ARROW_SIZE |" >> $GITHUB_STEP_SUMMARY
+          echo "| pkg/esm/arrow1_bg.wasm | $ARROW1_SIZE |" >> $GITHUB_STEP_SUMMARY
           echo "| pkg/esm/arrow1_bg.wasm.br | $ARROW1_BR_SIZE |" >> $GITHUB_STEP_SUMMARY
         # TODO: matrix equivalent of this / and/or use the @actions/core npm package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,4 +132,5 @@ jobs:
           echo "| ------ | ---- |" >> $GITHUB_STEP_SUMMARY
           echo "| pkg/esm/arrow1_bg.wasm | $ARROW1_SIZE |" >> $GITHUB_STEP_SUMMARY
           echo "| pkg/esm/arrow1_bg.wasm.br | $ARROW1_BR_SIZE |" >> $GITHUB_STEP_SUMMARY
+          echo $GITHUB_STEP_SUMMARY
         # TODO: matrix equivalent of this / and/or use the @actions/core npm package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            profile: minimal
-            override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -33,13 +29,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            profile: minimal
-            override: true
+            targets: wasm32-unknown-unknown
 
-      - run: rustup target add wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
 
       - run: cargo install cargo-all-features
@@ -53,11 +46,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            profile: minimal
-            override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -84,11 +73,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            profile: minimal
-            override: true
             components: rustfmt
 
       - uses: Swatinem/rust-cache@v2
@@ -103,11 +89,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            profile: minimal
-            override: true
             components: clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -121,11 +104,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            profile: minimal
-            override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -145,7 +124,8 @@ jobs:
       - name: Size Reporting
         run: |
           ARROW1_SIZE=$(cat pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null)
-          ARROW1_BR_SIZE=$(brotli -Z -c pkg/esm/arrow1_bg.wasm | pv -f -b 2>&1 >/dev/null)
+          brotli -Z pkg/esm/arrow1_bg.wasm
+          ARROW1_BR_SIZE=$(cat pkg/esm/arrow1_bg.wasm.br | pv -f -b 2>&1 >/dev/null)
           echo $ARROW1_SIZE
           echo $ARROW1_BR_SIZE
           echo "| Asset  | Size |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           name: pr
           path: pr/
-      - name: 'Download artifact'
+      - name: 'Generate size deltas'
         uses: actions/github-script@v7
         with:
           script: |
@@ -218,8 +218,8 @@ jobs:
                     ...v,
                     ...Object.fromEntries(['size', 'compressed_size'].map(subK => {
                         // compute the percentage change, NaN if the asset wasn't available
-                        const proportionalDelta = 1 - v?.[subK] / baseAsset?.[subK];
-                        const absoluteDelta = baseAsset?.[subK] - v?.[subK]
+                        const proportionalDelta = v?.[subK] / baseAsset?.[subK] - 1;
+                        const absoluteDelta = v?.[subK] - baseAsset?.[subK]
                         const sign = Math.sign(proportionalDelta);
                         // conditionally color the output via an inline latex block
                         let fragment = '';
@@ -239,7 +239,7 @@ jobs:
                 // output a markdown fragment
                 const sizeFragment = `${formatter.format(size)} ${size_delta}`
                 const compressedFragment = `${formatter.format(compressed_size)} ${compressed_size_delta}`
-                return [asset, sizeFragment, compressedFragment]
+                return [asset.replace('report_pkg/', ''), sizeFragment, compressedFragment]
             });
             await core.summary.addHeading('Asset Sizes').addTable([
               [{data: 'Asset', header: true}, {data: 'Uncompressed Size', header: true}, {data: 'Compressed Size', header: true}],

--- a/scripts/report_build.sh
+++ b/scripts/report_build.sh
@@ -1,0 +1,30 @@
+rm -rf report_pkg
+mkdir -p report_pkg
+
+echo "Building arrow-rs slim"
+wasm-pack build \
+  --release \
+  --no-pack \
+  --out-dir report_pkg/slim \
+  --out-name arrow1 \
+  --target web \
+  --features=arrow1 &
+echo "Building arrow-rs sync"
+wasm-pack build \
+  --release \
+  --no-pack \
+  --out-dir report_pkg/sync \
+  --out-name arrow1 \
+  --target web \
+  --features={arrow1,reader,writer,all_compressions} &
+
+echo "Building arrow-rs async_full"
+wasm-pack build \
+  --release \
+  --no-pack \
+  --out-dir report_pkg/async_full \
+  --out-name arrow1 \
+  --target web \
+  --features={arrow1,reader,writer,all_compressions,async} &
+
+wait;


### PR DESCRIPTION
I would have liked to do a head vs target % change (apparently there's a way involving artifacts), but this is a sufficiently useful gauge. Presumably the artifacts required for that would also be used in package publishing.

As far as I can tell, it's only the JS bindings that differ between targets, so we can probably just do `pkg/esm/*.wasm` and be done with it.