### PR TITLE
feat:  add lz4_raw support for `arrow1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1050,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.0",
+ "lz4_flex",
  "num",
  "num-bigint",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,9 @@ brotli = ["parquet/brotli"]
 gzip = ["parquet/flate2"]
 snappy = ["parquet/snap"]
 zstd = ["parquet/zstd", "dep:zstd"]
-# LZ4 not yet supported on parquet crate
-# lz4 = ["parquet2?/lz4_flex"]
+lz4 = ["parquet/lz4"]
 
-all_compressions = ["brotli", "gzip", "snappy", "zstd"] # "lz4"
+all_compressions = ["brotli", "gzip", "snappy", "zstd", "lz4"]
 
 # Full list of available features
 full = [

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ The Parquet specification permits several compression codecs. This library curre
 - [x] Gzip
 - [x] Brotli
 - [x] ZSTD
+- [x] LZ4_RAW
 - [ ] LZ4 (deprecated)
-- [x] LZ4_RAW. Supported in `arrow2` only.
 
 LZ4 support in Parquet is a bit messy. As described [here](https://github.com/apache/parquet-format/blob/54e53e5d7794d383529dd30746378f19a12afd58/Compression.md), there are _two_ LZ4 compression options in Parquet (as of version 2.9.0). The original version `LZ4` is now deprecated; it used an undocumented framing scheme which made interoperability difficult. The specification now reads:
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ By default, `arrow`, `all_compressions`, `reader`, and `writer` features are ena
 - `gzip`: Activate Gzip compression.
 - `snappy`: Activate Snappy compression.
 - `zstd`: Activate ZSTD compression.
-- `lz4`: Activate LZ4_RAW compression (only applies to the `arrow2` endpoints).
+- `lz4`: Activate LZ4_RAW compression.
 - `debug`: Expose the `setPanicHook` function for better error messages for Rust panics.
 
 ## Node <20

--- a/src/writer_properties.rs
+++ b/src/writer_properties.rs
@@ -27,8 +27,7 @@ impl From<Compression> for parquet::basic::Compression {
             Compression::BROTLI => parquet::basic::Compression::BROTLI(BrotliLevel::default()),
             Compression::LZ4 => parquet::basic::Compression::LZ4,
             Compression::ZSTD => parquet::basic::Compression::ZSTD(ZstdLevel::default()),
-            // TODO: fix this. Though LZ4 isn't supported in arrow1 for wasm anyways
-            Compression::LZ4_RAW => parquet::basic::Compression::LZ4,
+            Compression::LZ4_RAW => parquet::basic::Compression::LZ4_RAW,
         }
     }
 }


### PR DESCRIPTION
It seems like the arrow crate has gained support for `lz4_raw` [some time ago](https://github.com/apache/arrow-rs/commit/4e1247e8c03f36940a912256e2d94f49a1b581df) behind the `lz4` flag.
