### PR TITLE
Update async API

### DIFF
--- a/src/read_options.rs
+++ b/src/read_options.rs
@@ -1,5 +1,9 @@
+use parquet::arrow::arrow_reader::ArrowReaderBuilder;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
+
+use crate::error::Result;
+use crate::reader_async::generate_projection_mask;
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_ReaderOptions: &'static str = r#"
@@ -12,6 +16,10 @@ export type ReaderOptions = {
     limit?: number;
     /* Provide an offset to skip over the given number of rows. */
     offset?: number;
+    /* The column names from the file to read. */
+    columns?: string[];
+    /* The number of concurrent requests to make in the async reader. */
+    concurrency?: number;
 };
 "#;
 
@@ -21,7 +29,7 @@ extern "C" {
     pub type ReaderOptions;
 }
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct JsReaderOptions {
     /// The number of rows in each batch. If not provided, the upstream parquet default is 1024.
@@ -35,12 +43,46 @@ pub struct JsReaderOptions {
 
     /// Provide an offset to skip over the given number of rows
     pub offset: Option<usize>,
+
+    /// The column names from the file to read.
+    pub columns: Option<Vec<String>>,
+
+    /// The number of concurrent requests to make in the async reader.
+    pub concurrency: Option<usize>,
+}
+
+impl JsReaderOptions {
+    pub fn apply_to_builder<T>(
+        &self,
+        mut builder: ArrowReaderBuilder<T>,
+    ) -> Result<ArrowReaderBuilder<T>> {
+        if let Some(batch_size) = self.batch_size {
+            builder = builder.with_batch_size(batch_size);
+        }
+
+        if let Some(limit) = self.limit {
+            builder = builder.with_limit(limit);
+        }
+
+        if let Some(offset) = self.offset {
+            builder = builder.with_offset(offset);
+        }
+
+        if let Some(columns) = &self.columns {
+            let parquet_schema = builder.parquet_schema();
+            let projection_mask = generate_projection_mask(columns, parquet_schema)?;
+
+            builder = builder.with_projection(projection_mask);
+        }
+
+        Ok(builder)
+    }
 }
 
 impl TryFrom<ReaderOptions> for JsReaderOptions {
     type Error = serde_wasm_bindgen::Error;
 
-    fn try_from(value: ReaderOptions) -> Result<Self, Self::Error> {
+    fn try_from(value: ReaderOptions) -> std::result::Result<Self, Self::Error> {
         serde_wasm_bindgen::from_value(value.obj)
     }
 }

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -89,13 +89,9 @@ pub struct ParquetFile {
 impl ParquetFile {
     /// Construct a ParquetFile from a new URL.
     ///
-    /// @param options The options to pass into `object-store`'s [`parse_url_opts`]
+    /// @param options The options to pass into `object-store`'s [`parse_url_opts`][parse_url_opts]
     ///
     /// [parse_url_opts]: https://docs.rs/object_store/latest/object_store/fn.parse_url_opts.html
-    /// [File]: https://developer.mozilla.org/en-US/docs/Web/API/File
-    ///
-    /// Safety: Do not use this in a multi-threaded environment,
-    /// (transitively depends on !Send web_sys::File)
     #[wasm_bindgen(js_name = fromUrl)]
     pub async fn from_url(url: String, options: Option<js_sys::Map>) -> WasmResult<ParquetFile> {
         let parsed_url = Url::parse(&url)?;
@@ -121,7 +117,7 @@ impl ParquetFile {
     /// [File]: https://developer.mozilla.org/en-US/docs/Web/API/File
     ///
     /// Safety: Do not use this in a multi-threaded environment,
-    /// (transitively depends on !Send web_sys::File)
+    /// (transitively depends on `!Send` `web_sys::File`)
     #[wasm_bindgen(js_name = fromFile)]
     pub async fn from_file(handle: web_sys::File) -> WasmResult<ParquetFile> {
         let mut reader = JsFileReader::new(handle, 1024);
@@ -139,13 +135,16 @@ impl ParquetFile {
 
     /// Read from the Parquet file in an async fashion.
     ///
-    /// @param options Options for reading Parquet data. Optional keys include:
-    ///     - batchSize: The number of rows in each batch. If not provided, the upstream parquet
-    ///       default is 1024.
-    ///     - rowGroups: Only read data from the provided row group indexes.
-    ///     - limit: Provide a limit to the number of rows to be read.
-    ///     - offset: Provide an offset to skip over the given number of rows.
-    ///     - columns: The column names from the file to read.
+    /// @param options
+    ///
+    ///    Options for reading Parquet data. Optional keys include:
+    ///
+    ///    - `batchSize`: The number of rows in each batch. If not provided, the upstream parquet
+    ///           default is 1024.
+    ///    - `rowGroups`: Only read data from the provided row group indexes.
+    ///    - `limit`: Provide a limit to the number of rows to be read.
+    ///    - `offset`: Provide an offset to skip over the given number of rows.
+    ///    - `columns`: The column names from the file to read.
     #[wasm_bindgen]
     pub async fn read(&self, options: Option<ReaderOptions>) -> WasmResult<Table> {
         let options = options
@@ -165,14 +164,17 @@ impl ParquetFile {
     ///
     /// Each item in the stream will be a {@linkcode RecordBatch}.
     ///
-    /// @param options Options for reading Parquet data. Optional keys include:
-    ///     - batchSize: The number of rows in each batch. If not provided, the upstream parquet
-    ///       default is 1024.
-    ///     - rowGroups: Only read data from the provided row group indexes.
-    ///     - limit: Provide a limit to the number of rows to be read.
-    ///     - offset: Provide an offset to skip over the given number of rows.
-    ///     - columns: The column names from the file to read.
-    ///     - concurrency: The number of concurrent requests to make
+    /// @param options
+    ///
+    ///    Options for reading Parquet data. Optional keys include:
+    ///
+    ///    - `batchSize`: The number of rows in each batch. If not provided, the upstream parquet
+    ///           default is 1024.
+    ///    - `rowGroups`: Only read data from the provided row group indexes.
+    ///    - `limit`: Provide a limit to the number of rows to be read.
+    ///    - `offset`: Provide an offset to skip over the given number of rows.
+    ///    - `columns`: The column names from the file to read.
+    ///    - `concurrency`: The number of concurrent requests to make
     #[wasm_bindgen]
     pub async fn stream(
         &self,

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -168,7 +168,7 @@ impl ParquetFile {
     ///
     ///    - `batchSize`: The number of rows in each batch. If not provided, the upstream parquet
     ///           default is 1024.
-    ///    - `rowGroups`: Only read data from the provided row group indexes.
+    ///    - ~~`rowGroups`: Only read data from the provided row group indexes.~~ **The rowGroups parameter does not yet take effect here.**
     ///    - `limit`: Provide a limit to the number of rows to be read.
     ///    - `offset`: Provide an offset to skip over the given number of rows.
     ///    - `columns`: The column names from the file to read.
@@ -188,6 +188,7 @@ impl ParquetFile {
         // TODO: enable row group selection
         // let row_groups = options
         //     .row_groups
+        //     .clone()
         //     .unwrap_or_else(|| (0..self.meta.metadata().num_row_groups()).collect());
         // let row_groups_slice = row_groups.as_slice();
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -53,12 +53,16 @@ use wasm_bindgen::prelude::*;
 /// ```
 ///
 /// @param parquet_file Uint8Array containing Parquet data
-/// @param options Options for reading Parquet data. Optional keys include:
-///     - batchSize: The number of rows in each batch. If not provided, the upstream parquet
-///       default is 1024.
-///     - rowGroups: Only read data from the provided row group indexes.
-///     - limit: Provide a limit to the number of rows to be read.
-///     - offset: Provide an offset to skip over the given number of rows.
+/// @param options
+///
+///    Options for reading Parquet data. Optional keys include:
+///
+///    - `batchSize`: The number of rows in each batch. If not provided, the upstream parquet
+///           default is 1024.
+///    - `rowGroups`: Only read data from the provided row group indexes.
+///    - `limit`: Provide a limit to the number of rows to be read.
+///    - `offset`: Provide an offset to skip over the given number of rows.
+///    - `columns`: The column names from the file to read.
 #[wasm_bindgen(js_name = readParquet)]
 #[cfg(feature = "reader")]
 pub fn read_parquet(parquet_file: Vec<u8>, options: Option<ReaderOptions>) -> WasmResult<Table> {
@@ -230,7 +234,7 @@ pub fn write_parquet(
 /// const table = new arrow.Table(batches);
 /// ```
 ///
-/// @param parquet_file Uint8Array containing Parquet data
+/// @param url URL to Parquet file
 #[wasm_bindgen(js_name = readParquetStream)]
 #[cfg(all(feature = "reader", feature = "async"))]
 pub async fn read_parquet_stream(


### PR DESCRIPTION
### Change list

- Rename `AsyncParquetFile` to `ParquetFile`
- Combine object-store reader and local file reader into single `ParquetFile` API. 
- Remove `SharedIO` trait, since now we only have a single struct.
- Remove `with_batch_size` and `select_columns`. I don't see a need for the `ParquetFile` struct itself to maintain any reader state. That information is only used in the read phase, not the constructor phase, and so I think it's fine to pass those options into `read` or `stream`.
- Remove `readRowGroup` in favor of `read`. `read` now has options including a `rowGroups` parameter, that takes a list of integers.
- Define `ReaderOptions` struct for read options, used by both sync and async readers.


I couldn't get the row group selection to work in `stream()` here
https://github.com/kylebarron/parquet-wasm/pull/510/files#diff-e1a77beecd2634c6c0489c20cc3cae036ed6668d62c4d47f00760ab60b0d404eR188-R192

I was hitting lifetime errors with having a `Vec<usize>` there that wouldn't live long enough for the stream.

@H-Plus-Time I'd like to get a release out in the next day or two, because otherwise I'll forget about it again and it'll never get released. I already did a lot of other cleanup, so I think it's just this and a little more README updates and then I'm ready to publish 0.6. I don't want to spend a lot more time on this. But I wanted to give you a heads up in case you wanted to make any more edits before the release!