### PR TITLE
Remove compressions from check-all-features

### DIFF
--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -12,11 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-            targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
 
@@ -75,7 +75,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-            components: rustfmt
+          components: rustfmt
 
       - uses: Swatinem/rust-cache@v2
 
@@ -91,7 +91,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-            components: clippy
+          components: clippy
 
       - uses: Swatinem/rust-cache@v2
 
@@ -106,7 +106,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-            targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -140,7 +140,7 @@ jobs:
           if [[ "${{ github.event_type }}" != "pull_request" ]]; then
             cat ./pr/step_summary.md > $GITHUB_STEP_SUMMARY
           fi;
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/
@@ -150,11 +150,11 @@ jobs:
       github.event_name == 'pull_request'
     needs: node-build-report
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pr
           path: pr/
-      - name: 'Generate size deltas'
+      - name: "Generate size deltas"
         uses: actions/github-script@v7
         with:
           script: |
@@ -186,10 +186,10 @@ jobs:
                 artifact_id: matchArtifact.id,
                 archive_format: 'zip',
               });
-                
+
               fs.writeFileSync('${{github.workspace}}/base.zip', Buffer.from(download.data));
               execSync(`unzip -p base.zip asset_manifest.json >base_asset_manifest.json || true`);
-            } 
+            }
             // now, read in the asset manifests, for the head and base
             let baseAssets = {};
             try {
@@ -246,7 +246,7 @@ jobs:
               ...lineFragments
             ]).write();
             fs.cpSync(process.env.GITHUB_STEP_SUMMARY, './pr/step_summary.md')
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,7 +246,7 @@ jobs:
               ...lineFragments
             ]).write();
             fs.cpSync(process.env.GITHUB_STEP_SUMMARY, './pr/step_summary.md')
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pr
-          path: pr/
+      # - uses: actions/upload-artifact@v4
+      #   with:
+      #     name: pr
+      #     path: pr/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,16 @@ wasm-bindgen-test = "0.3.45"
 skip_optional_dependencies = true
 
 # Exclude certain features from the build matrix
-denylist = ["full", "all_compressions", "default"]
+denylist = [
+  "full",
+  "all_compressions",
+  "default",
+  "brotli",
+  "gzip",
+  "snappy",
+  "zstd",
+  "lz4",
+]
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.


### PR DESCRIPTION
We shouldn't need to check all combinations of the compressors features, because we don't do anything in our own user code about that. Those only get passed on to the upstream `parquet` crate, and it's their problem if a combination of decompressors is invalid. 

This speeds up the `check` CI run **from 10.5 minutes to 1 minute**

We really just want to check:

```
reader 
writer 
async 
debug 
```