### PR TITLE
Support rowGroups option in ParquetFile.read

### DIFF
--- a/src/read_options.rs
+++ b/src/read_options.rs
@@ -77,6 +77,10 @@ impl JsReaderOptions {
             builder = builder.with_projection(projection_mask);
         }
 
+        if let Some(row_groups) = &self.row_groups {
+          builder = builder.with_row_groups(row_groups.clone());
+        }
+
         Ok(builder)
     }
 }


### PR DESCRIPTION
I found that when using a remote ParquetFile and calling `read` with options, the `rowGroups` option had no effect—the end result would always have the full set of row groups in the file. Digging in, I saw that the `stream` method in [reader_async](https://github.com/kylebarron/parquet-wasm/blob/main/src/reader_async.rs) called `with_row_groups` on the builder. But neither `read` nor `JsReaderOptions::apply_to_builder` called `with_row_groups`. 

```js
const file = await ParquetFile.fromUrl(url)

const table = await file.read({
  rowGroups:  [0],     // did NOT reduce final table size
  columns:    cols,    // this option works
  limit: 5,            // this option works
})
```

So this change adds the `with_row_groups` in options-apply.  I don't know if this is more appropriately in `read` itself, or if it might have side effects in `stream` or `read_row_group` from a double-call... but this worked for me to get `read` selecting just the groups of interest!

And many thanks for building this project and arrow-js-ffi and all the others, I'm learning my way around geoparquet and am really appreciating these foundations!

Followup to #505