### PR TITLE
feature: add support for slicing above i32 where u64 can safely be coerced to f64 losslessly

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,7 @@ impl From<ParquetWasmError> for ParquetError {
                 ParquetError::ArrowError(arrow_error.to_string())
             }
             ParquetWasmError::ParquetError(parquet_error) => *parquet_error,
+            #[cfg(feature = "async")]
             ParquetWasmError::HTTPError(error) => ParquetError::External(error),
             ParquetWasmError::PlatformSupportError(x) => ParquetError::General(x),
             e => ParquetError::General(e.to_string()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,3 +42,19 @@ impl From<reqwest::Error> for ParquetWasmError {
         Self::HTTPError(Box::new(err))
     }
 }
+
+impl From<ParquetWasmError> for ParquetError {
+    fn from(value: ParquetWasmError) -> Self {
+        // We cannot use the `External` variant as it requires that `ParquetWasmError`
+        // be Send, which `JsValue` is not
+        match value {
+            ParquetWasmError::ArrowError(arrow_error) => {
+                ParquetError::ArrowError(arrow_error.to_string())
+            }
+            ParquetWasmError::ParquetError(parquet_error) => *parquet_error,
+            ParquetWasmError::HTTPError(error) => ParquetError::External(error),
+            ParquetWasmError::PlatformSupportError(x) => ParquetError::General(x),
+            e => ParquetError::General(e.to_string()),
+        }
+    }
+}

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -11,9 +11,9 @@ use crate::utils;
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
 use object_store::coalesce_ranges;
+use std::io;
 use std::ops::Range;
 use std::sync::Arc;
-use std::io;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 
@@ -329,12 +329,19 @@ impl WrappedFile {
         let file = self.inner.clone();
         spawn_local(async move {
             if range.start <= utils::MAX_EXACT_INTEGER && range.end <= utils::MAX_EXACT_INTEGER {
-                let subset_blob = file.slice_with_f64_and_f64(range.start as f64, range.end as f64).unwrap();
+                let subset_blob = file
+                    .slice_with_f64_and_f64(range.start as f64, range.end as f64)
+                    .unwrap();
                 let buf = JsFuture::from(subset_blob.array_buffer()).await.unwrap();
                 let out_vec = Uint8Array::new_with_byte_offset(&buf, 0).to_vec();
                 sender.send(Ok(out_vec)).unwrap();
             } else {
-                sender.send(Err(io::Error::new(io::ErrorKind::Unsupported, format!("{range:?} is too large to convert into a Blob slice")))).unwrap();
+                sender
+                    .send(Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!("{range:?} is too large to convert into a Blob slice"),
+                    )))
+                    .unwrap();
             };
         });
 
@@ -350,7 +357,7 @@ async fn get_bytes_file(
     spawn_local(async move {
         let result = match file.get_bytes(range).await {
             Ok(result) => Ok(Bytes::from(result)),
-            Err(e) => Err(e)
+            Err(e) => Err(e),
         };
         sender.send(result).unwrap()
     });

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -326,9 +326,9 @@ impl WrappedFile {
         let (sender, receiver) = oneshot::channel();
         let file = self.inner.clone();
         spawn_local(async move {
-            let subset_blob = if (range.start <= i32::MAX as u64) && (range.end <= i32::MAX as u64) {
-                file
-                .slice_with_i32_and_i32(
+            let subset_blob = if (range.start <= i32::MAX as u64) && (range.end <= i32::MAX as u64)
+            {
+                file.slice_with_i32_and_i32(
                     range.start.try_into().unwrap(),
                     range.end.try_into().unwrap(),
                 )

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -326,12 +326,24 @@ impl WrappedFile {
         let (sender, receiver) = oneshot::channel();
         let file = self.inner.clone();
         spawn_local(async move {
-            let subset_blob = file
+            let subset_blob = if (range.start <= i32::MAX as u64) && (range.end <= i32::MAX as u64) {
+                file
                 .slice_with_i32_and_i32(
                     range.start.try_into().unwrap(),
                     range.end.try_into().unwrap(),
                 )
-                .unwrap();
+                .unwrap()
+            } else {
+                let start = range.start as f64;
+                if start as u64 != range.start {
+                    panic!("Cannot safely convert start index of {range:?}");
+                }
+                let end = range.end as f64;
+                if end as u64 != range.end {
+                    panic!("Cannot safely convert start index of {range:?}");
+                }
+                file.slice_with_f64_and_f64(start, end).unwrap()
+            };
             let buf = JsFuture::from(subset_blob.array_buffer()).await.unwrap();
             let out_vec = Uint8Array::new_with_byte_offset(&buf, 0).to_vec();
             sender.send(out_vec).unwrap();

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -11,7 +11,7 @@ use crate::utils;
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
 use object_store::coalesce_ranges;
-use std::io;
+use parquet::errors::ParquetError;
 use std::ops::Range;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
@@ -322,7 +322,7 @@ impl WrappedFile {
         Self { inner, size }
     }
 
-    pub async fn get_bytes(&mut self, range: Range<u64>) -> io::Result<Vec<u8>> {
+    pub async fn get_bytes(&mut self, range: Range<u64>) -> crate::error::Result<Vec<u8>> {
         use js_sys::Uint8Array;
         use wasm_bindgen_futures::JsFuture;
         let (sender, receiver) = oneshot::channel();
@@ -337,8 +337,7 @@ impl WrappedFile {
                 sender.send(Ok(out_vec)).unwrap();
             } else {
                 sender
-                    .send(Err(io::Error::new(
-                        io::ErrorKind::Unsupported,
+                    .send(Err(crate::error::ParquetWasmError::PlatformSupportError(
                         format!("{range:?} is too large to convert into a Blob slice"),
                     )))
                     .unwrap();
@@ -355,14 +354,14 @@ async fn get_bytes_file(
 ) -> parquet::errors::Result<Bytes> {
     let (sender, receiver) = oneshot::channel();
     spawn_local(async move {
-        let result = match file.get_bytes(range).await {
-            Ok(result) => Ok(Bytes::from(result)),
-            Err(e) => Err(e),
-        };
+        let result = file
+            .get_bytes(range)
+            .await
+            .map(Bytes::from)
+            .map_err(ParquetError::from);
         sender.send(result).unwrap()
     });
-    let data = receiver.await.unwrap()?;
-    Ok(data)
+    receiver.await.unwrap()
 }
 
 #[derive(Debug, Clone)]
@@ -386,11 +385,14 @@ impl AsyncFileReader for JsFileReader {
             let (sender, receiver) = oneshot::channel();
             let mut file = self.file.clone();
             spawn_local(async move {
-                let result = file.get_bytes(range).await.map(Bytes::from);
+                let result = file
+                    .get_bytes(range)
+                    .await
+                    .map(Bytes::from)
+                    .map_err(ParquetError::from);
                 sender.send(result).unwrap()
             });
-            let data = receiver.await.unwrap();
-            Ok(data?)
+            receiver.await.unwrap()
         }
         .boxed()
     }

--- a/src/reader_async.rs
+++ b/src/reader_async.rs
@@ -7,11 +7,13 @@ use crate::common::fetch::{
 use crate::error::{Result, WasmResult};
 use crate::read_options::{JsReaderOptions, ReaderOptions};
 use crate::reader::cast_metadata_view_types;
+use crate::utils;
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
 use object_store::coalesce_ranges;
 use std::ops::Range;
 use std::sync::Arc;
+use std::io;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 
@@ -320,33 +322,20 @@ impl WrappedFile {
         Self { inner, size }
     }
 
-    pub async fn get_bytes(&mut self, range: Range<u64>) -> Vec<u8> {
+    pub async fn get_bytes(&mut self, range: Range<u64>) -> io::Result<Vec<u8>> {
         use js_sys::Uint8Array;
         use wasm_bindgen_futures::JsFuture;
         let (sender, receiver) = oneshot::channel();
         let file = self.inner.clone();
         spawn_local(async move {
-            let subset_blob = if (range.start <= i32::MAX as u64) && (range.end <= i32::MAX as u64)
-            {
-                file.slice_with_i32_and_i32(
-                    range.start.try_into().unwrap(),
-                    range.end.try_into().unwrap(),
-                )
-                .unwrap()
+            if range.start <= utils::MAX_EXACT_INTEGER && range.end <= utils::MAX_EXACT_INTEGER {
+                let subset_blob = file.slice_with_f64_and_f64(range.start as f64, range.end as f64).unwrap();
+                let buf = JsFuture::from(subset_blob.array_buffer()).await.unwrap();
+                let out_vec = Uint8Array::new_with_byte_offset(&buf, 0).to_vec();
+                sender.send(Ok(out_vec)).unwrap();
             } else {
-                let start = range.start as f64;
-                if start as u64 != range.start {
-                    panic!("Cannot safely convert start index of {range:?}");
-                }
-                let end = range.end as f64;
-                if end as u64 != range.end {
-                    panic!("Cannot safely convert start index of {range:?}");
-                }
-                file.slice_with_f64_and_f64(start, end).unwrap()
+                sender.send(Err(io::Error::new(io::ErrorKind::Unsupported, format!("{range:?} is too large to convert into a Blob slice")))).unwrap();
             };
-            let buf = JsFuture::from(subset_blob.array_buffer()).await.unwrap();
-            let out_vec = Uint8Array::new_with_byte_offset(&buf, 0).to_vec();
-            sender.send(out_vec).unwrap();
         });
 
         receiver.await.unwrap()
@@ -359,10 +348,13 @@ async fn get_bytes_file(
 ) -> parquet::errors::Result<Bytes> {
     let (sender, receiver) = oneshot::channel();
     spawn_local(async move {
-        let result: Bytes = file.get_bytes(range).await.into();
+        let result = match file.get_bytes(range).await {
+            Ok(result) => Ok(Bytes::from(result)),
+            Err(e) => Err(e)
+        };
         sender.send(result).unwrap()
     });
-    let data = receiver.await.unwrap();
+    let data = receiver.await.unwrap()?;
     Ok(data)
 }
 
@@ -387,11 +379,11 @@ impl AsyncFileReader for JsFileReader {
             let (sender, receiver) = oneshot::channel();
             let mut file = self.file.clone();
             spawn_local(async move {
-                let result: Bytes = file.get_bytes(range).await.into();
+                let result = file.get_bytes(range).await.map(Bytes::from);
                 sender.send(result).unwrap()
             });
             let data = receiver.await.unwrap();
-            Ok(data)
+            Ok(data?)
         }
         .boxed()
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 use wasm_bindgen::prelude::*;
 
+pub const MAX_EXACT_INTEGER: u64 = ((1u64 << f64::MANTISSA_DIGITS) - 1) as u64;
+
 /// Call this function at least once during initialization to get better error
 // messages if the underlying Rust code ever panics (creates uncaught errors).
 #[cfg(feature = "console_error_panic_hook")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::prelude::*;
 
-pub const MAX_EXACT_INTEGER: u64 = ((1u64 << f64::MANTISSA_DIGITS) - 1) as u64;
+pub const MAX_EXACT_INTEGER: u64 = (1u64 << f64::MANTISSA_DIGITS) - 1;
 
 /// Call this function at least once during initialization to get better error
 // messages if the underlying Rust code ever panics (creates uncaught errors).


### PR DESCRIPTION
Right now, if I try to read a Parquet file that is larger than 2**31 bytes, `WrappedFile::get_bytes` panics because it cannot coerce the `u64` byte range to `i32`. This change relaxes the limit, checking that we can round-trip the indices from `u64` -> `f64` -> `u64` without loss of precision and then uses the f64 representation to slice the `Blob` with.

This *might* also be doable with a check for the value being less than `Number.MAX_SAFE_INTEGER`, but I didn't see a good way to query that from WASM, though I doubt it _can_ change.
