### PR TITLE
fix: use correct module type for `node/` (cjs)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -55,6 +55,9 @@ jq -s '.[0] * .[1]' templates/package.json tmp_build/bundler/package.json > pkg/
 # Create minimal package.json in esm/ folder with type: module
 echo '{"type": "module"}' > pkg/esm/package.json
 
+# Create minimal package.json in node/ folder with type: commonjs
+echo '{"type": "commonjs"}' > pkg/node/package.json
+
 # Update files array in package.json using JQ
 jq '.files = ["*"] | .module="esm/parquet_wasm.js" | .types="esm/parquet_wasm.d.ts"' pkg/package.json > pkg/package.json.tmp
 


### PR DESCRIPTION
Currently, we build `esm`, `bundler` and `node` (CJS) targets. However, the main `package.json` inherits `{ "type": "module" }` set by the `bundler` output during copying in https://github.com/kylebarron/parquet-wasm/blob/2dbda639f0cd4661ddc92e36e82aaebd82accfde/scripts/build.sh#L53

This means that our CJS export `node/` has type `module` so any CJS Node.JS application would fail to import it.

By simply adding `{"type": "commonjs"}` to node/package.json, we ensure that node can correctly resolve the right type for that target.

This fixes https://github.com/kylebarron/parquet-wasm/issues/798